### PR TITLE
Day-specific events on shared templates

### DIFF
--- a/desktopApp/src/main/kotlin/dev/nucleus/scheduleit/InAppNotificationLoop.kt
+++ b/desktopApp/src/main/kotlin/dev/nucleus/scheduleit/InAppNotificationLoop.kt
@@ -2,6 +2,8 @@ package dev.nucleus.scheduleit
 
 import dev.nucleus.scheduleit.data.ScheduleRepository
 import dev.nucleus.scheduleit.domain.AppDayOfWeek
+import dev.nucleus.scheduleit.domain.EffectiveEvent
+import dev.nucleus.scheduleit.domain.effectiveEventsFor
 import dev.nucleus.scheduleit.presentation.schedule.ScheduleViewModel
 import dev.nucleus.scheduleit.ui.common.formatTime
 import io.github.kdroidfilter.nucleus.notification.common.NotificationManager
@@ -23,7 +25,7 @@ import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
 fun CoroutineScope.startInAppNotificationLoop(repository: ScheduleRepository): Job = launch {
-    val sentInWindow = mutableSetOf<Long>()
+    val sentInWindow = mutableSetOf<String>()
     var lastWindowKey = ""
     while (true) {
         runCatching {
@@ -41,23 +43,30 @@ fun CoroutineScope.startInAppNotificationLoop(repository: ScheduleRepository): J
                     lastWindowKey = windowKey
                 }
                 val today = AppDayOfWeek.fromIso(now.dayOfWeek.isoDayNumber)
-                val templateId = snapshot.assignments[today]
-                if (templateId != null) {
+                if (today in snapshot.assignments || snapshot.dayEventsByDay.containsKey(today)) {
                     val defaultTitle = getString(Res.string.notification_default_title)
-                    snapshot.eventsByTemplate[templateId].orEmpty()
-                        .filter { it.startMinute in windowStart until windowEnd && it.id !in sentInWindow }
-                        .forEach { event ->
-                            val title = event.title.ifEmpty { defaultTitle }
+                    snapshot.effectiveEventsFor(today)
+                        .filter { it.startMinute in windowStart until windowEnd }
+                        .forEach { effective ->
+                            val key = effective.notificationKey()
+                            if (key in sentInWindow) return@forEach
+                            val title = effective.title.ifEmpty { defaultTitle }
                             val message = getString(
                                 Res.string.notification_starts_at,
-                                formatTime(event.startMinute),
+                                formatTime(effective.startMinute),
                             )
                             notification(title = title, message = message).send()
-                            sentInWindow += event.id
+                            sentInWindow += key
                         }
                 }
             }
         }
         delay(20.seconds)
     }
+}
+
+private fun EffectiveEvent.notificationKey(): String = when (val s = source) {
+    is EffectiveEvent.Source.TemplateShared -> "tpl:${s.event.id}"
+    is EffectiveEvent.Source.TemplateOverridden -> "ovr:${s.base.id}:${day.isoIndex}"
+    is EffectiveEvent.Source.DayOnly -> "day:${s.event.id}"
 }

--- a/desktopApp/src/main/kotlin/dev/nucleus/scheduleit/ScheduleItMenuBar.kt
+++ b/desktopApp/src/main/kotlin/dev/nucleus/scheduleit/ScheduleItMenuBar.kt
@@ -48,7 +48,9 @@ fun ScheduleItMenuBar(onQuit: () -> Unit) {
 
     val targetDay = pickTargetDay(state.assignments.keys)
     val canCreate = targetDay != null
-    val canExport = state.eventsByTemplate.values.any { it.isNotEmpty() }
+    val canExport = state.eventsByTemplate.values.any { it.isNotEmpty() } ||
+        state.dayEventsByDay.values.any { it.isNotEmpty() } ||
+        state.overridesByDay.isNotEmpty()
 
     NativeMenuBar {
         Menu(fileTitle) {

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -57,6 +57,10 @@
     <string name="event_field_color">Couleur</string>
     <string name="event_field_notes">Notes</string>
     <string name="event_time_format">%02d:%02d</string>
+    <string name="event_scope_label">Portée</string>
+    <string name="event_scope_this_day">Uniquement %1$s</string>
+    <string name="event_scope_all_days">Tous les jours liés</string>
+    <string name="action_hide_for_day">Masquer pour %1$s</string>
 
     <string name="empty_schedule_hint">Aucun jour visible. Ouvrez les paramètres pour activer des jours.</string>
     <string name="error_invalid_range">La fin doit être postérieure au début.</string>

--- a/shared/src/commonMain/composeResources/values-he/strings.xml
+++ b/shared/src/commonMain/composeResources/values-he/strings.xml
@@ -57,6 +57,10 @@
     <string name="event_field_color">צבע</string>
     <string name="event_field_notes">הערות</string>
     <string name="event_time_format">%02d:%02d</string>
+    <string name="event_scope_label">תחולה</string>
+    <string name="event_scope_this_day">רק %1$s</string>
+    <string name="event_scope_all_days">כל הימים המקושרים</string>
+    <string name="action_hide_for_day">הסתר עבור %1$s</string>
 
     <string name="empty_schedule_hint">אין יום גלוי. פתח את ההגדרות כדי להפעיל ימים.</string>
     <string name="error_invalid_range">הסיום חייב להיות אחרי ההתחלה.</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -57,6 +57,10 @@
     <string name="event_field_color">Color</string>
     <string name="event_field_notes">Notes</string>
     <string name="event_time_format">%02d:%02d</string>
+    <string name="event_scope_label">Scope</string>
+    <string name="event_scope_this_day">Only %1$s</string>
+    <string name="event_scope_all_days">All linked days</string>
+    <string name="action_hide_for_day">Hide for %1$s</string>
 
     <string name="empty_schedule_hint">No visible day. Open settings to enable days.</string>
     <string name="error_invalid_range">End must be after start.</string>

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/data/ScheduleBackup.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/data/ScheduleBackup.kt
@@ -1,10 +1,12 @@
 package dev.nucleus.scheduleit.data
 
 import dev.nucleus.scheduleit.domain.AppDayOfWeek
+import dev.nucleus.scheduleit.domain.DayEvent
 import dev.nucleus.scheduleit.domain.DayTemplate
 import dev.nucleus.scheduleit.domain.ScheduleEvent
 import dev.nucleus.scheduleit.domain.ScheduleSettings
 import dev.nucleus.scheduleit.domain.ScheduleSnapshot
+import dev.nucleus.scheduleit.domain.TemplateEventOverride
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -16,9 +18,11 @@ data class ScheduleBackup(
     val templates: List<BackupTemplate>,
     val assignments: List<BackupAssignment>,
     val events: List<BackupEvent>,
+    val dayEvents: List<BackupDayEvent> = emptyList(),
+    val overrides: List<BackupOverride> = emptyList(),
 ) {
     companion object {
-        const val CURRENT_VERSION = 1
+        const val CURRENT_VERSION = 2
     }
 }
 
@@ -52,6 +56,29 @@ data class BackupEvent(
     val notes: String,
 )
 
+@Serializable
+data class BackupDayEvent(
+    val id: Long,
+    val isoDay: Int,
+    val title: String,
+    val startMinute: Int,
+    val endMinute: Int,
+    val color: Long,
+    val notes: String,
+)
+
+@Serializable
+data class BackupOverride(
+    val baseEventId: Long,
+    val isoDay: Int,
+    val hidden: Boolean,
+    val title: String? = null,
+    val startMinute: Int? = null,
+    val endMinute: Int? = null,
+    val color: Long? = null,
+    val notes: String? = null,
+)
+
 private val backupJson = Json {
     prettyPrint = true
     ignoreUnknownKeys = true
@@ -79,6 +106,29 @@ fun ScheduleSnapshot.toBackup(): ScheduleBackup =
                 notes = e.notes,
             )
         },
+        dayEvents = dayEventsByDay.values.flatten().map { e ->
+            BackupDayEvent(
+                id = e.id,
+                isoDay = e.day.isoIndex,
+                title = e.title,
+                startMinute = e.startMinute,
+                endMinute = e.endMinute,
+                color = e.color,
+                notes = e.notes,
+            )
+        },
+        overrides = overridesByDay.values.flatMap { it.values }.map { ov ->
+            BackupOverride(
+                baseEventId = ov.baseEventId,
+                isoDay = ov.day.isoIndex,
+                hidden = ov.hidden,
+                title = ov.title,
+                startMinute = ov.startMinute,
+                endMinute = ov.endMinute,
+                color = ov.color,
+                notes = ov.notes,
+            )
+        },
     )
 
 fun ScheduleBackup.toSnapshot(): ScheduleSnapshot =
@@ -103,6 +153,31 @@ fun ScheduleBackup.toSnapshot(): ScheduleSnapshot =
                 notes = be.notes,
             )
         }.groupBy { it.templateId },
+        dayEventsByDay = dayEvents.map { be ->
+            DayEvent(
+                id = be.id,
+                day = AppDayOfWeek.fromIso(be.isoDay),
+                title = be.title,
+                startMinute = be.startMinute,
+                endMinute = be.endMinute,
+                color = be.color,
+                notes = be.notes,
+            )
+        }.groupBy { it.day },
+        overridesByDay = overrides.map { bo ->
+            TemplateEventOverride(
+                baseEventId = bo.baseEventId,
+                day = AppDayOfWeek.fromIso(bo.isoDay),
+                hidden = bo.hidden,
+                title = bo.title,
+                startMinute = bo.startMinute,
+                endMinute = bo.endMinute,
+                color = bo.color,
+                notes = bo.notes,
+            )
+        }.groupBy { it.day }.mapValues { (_, list) ->
+            list.associateBy { it.baseEventId }
+        },
     )
 
 fun ScheduleBackup.encodeToString(): String = backupJson.encodeToString(this)

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/data/ScheduleRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/data/ScheduleRepository.kt
@@ -5,10 +5,12 @@ import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOne
 import dev.nucleus.scheduleit.db.ScheduleDatabase
 import dev.nucleus.scheduleit.domain.AppDayOfWeek
+import dev.nucleus.scheduleit.domain.DayEvent
 import dev.nucleus.scheduleit.domain.DayTemplate
 import dev.nucleus.scheduleit.domain.ScheduleEvent
 import dev.nucleus.scheduleit.domain.ScheduleSettings
 import dev.nucleus.scheduleit.domain.ScheduleSnapshot
+import dev.nucleus.scheduleit.domain.TemplateEventOverride
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -69,8 +71,56 @@ class ScheduleRepository(
                 }.groupBy { it.templateId }
             }
 
-        return combine(settingsFlow, templatesFlow, assignmentsFlow, eventsFlow) { s, t, a, e ->
-            ScheduleSnapshot(s, t, a, e)
+        val dayEventsFlow = queries.selectAllDayEvents()
+            .asFlow()
+            .mapToList(ioDispatcher)
+            .map { rows ->
+                rows.map { row ->
+                    DayEvent(
+                        id = row.id,
+                        day = AppDayOfWeek.fromIso(row.day.toInt()),
+                        title = row.title,
+                        startMinute = row.start_minute.toInt(),
+                        endMinute = row.end_minute.toInt(),
+                        color = row.color,
+                        notes = row.notes,
+                    )
+                }.groupBy { it.day }
+            }
+
+        val overridesFlow = queries.selectAllOverrides()
+            .asFlow()
+            .mapToList(ioDispatcher)
+            .map { rows ->
+                rows.map { row ->
+                    TemplateEventOverride(
+                        baseEventId = row.base_event_id,
+                        day = AppDayOfWeek.fromIso(row.day.toInt()),
+                        hidden = row.hidden != 0L,
+                        title = row.title,
+                        startMinute = row.start_minute?.toInt(),
+                        endMinute = row.end_minute?.toInt(),
+                        color = row.color,
+                        notes = row.notes,
+                    )
+                }.groupBy { it.day }.mapValues { (_, list) ->
+                    list.associateBy { it.baseEventId }
+                }
+            }
+
+        val eventsBundleFlow = combine(eventsFlow, dayEventsFlow, overridesFlow) { byTpl, byDay, ov ->
+            Triple(byTpl, byDay, ov)
+        }
+
+        return combine(settingsFlow, templatesFlow, assignmentsFlow, eventsBundleFlow) { s, t, a, bundle ->
+            ScheduleSnapshot(
+                settings = s,
+                templates = t,
+                assignments = a,
+                eventsByTemplate = bundle.first,
+                dayEventsByDay = bundle.second,
+                overridesByDay = bundle.third,
+            )
         }.flowOn(ioDispatcher)
     }
 
@@ -147,6 +197,88 @@ class ScheduleRepository(
         queries.deleteEvent(id)
     }
 
+    suspend fun upsertDayEvent(event: DayEvent): Long = withContext(ioDispatcher) {
+        if (event.id == 0L) {
+            database.transactionWithResult {
+                queries.insertDayEvent(
+                    event.day.isoIndex.toLong(),
+                    event.title,
+                    event.startMinute.toLong(),
+                    event.endMinute.toLong(),
+                    event.color,
+                    event.notes,
+                )
+                queries.lastInsertedId().executeAsOne()
+            }
+        } else {
+            queries.updateDayEvent(
+                event.day.isoIndex.toLong(),
+                event.title,
+                event.startMinute.toLong(),
+                event.endMinute.toLong(),
+                event.color,
+                event.notes,
+                event.id,
+            )
+            event.id
+        }
+    }
+
+    suspend fun deleteDayEvent(id: Long) = withContext(ioDispatcher) {
+        queries.deleteDayEvent(id)
+    }
+
+    suspend fun upsertOverride(override: TemplateEventOverride) = withContext(ioDispatcher) {
+        queries.upsertOverride(
+            override.baseEventId,
+            override.day.isoIndex.toLong(),
+            if (override.hidden) 1L else 0L,
+            override.title,
+            override.startMinute?.toLong(),
+            override.endMinute?.toLong(),
+            override.color,
+            override.notes,
+        )
+    }
+
+    suspend fun deleteOverride(baseEventId: Long, day: AppDayOfWeek) = withContext(ioDispatcher) {
+        queries.deleteOverride(baseEventId, day.isoIndex.toLong())
+    }
+
+    suspend fun hideTemplateEventForDay(baseEventId: Long, day: AppDayOfWeek) {
+        upsertOverride(
+            TemplateEventOverride(
+                baseEventId = baseEventId,
+                day = day,
+                hidden = true,
+                title = null,
+                startMinute = null,
+                endMinute = null,
+                color = null,
+                notes = null,
+            ),
+        )
+    }
+
+    suspend fun promoteDayEventToTemplate(dayEventId: Long, templateId: Long): Long = withContext(ioDispatcher) {
+        database.transactionWithResult {
+            val rows = queries.selectAllDayEvents().executeAsList()
+            val source = rows.firstOrNull { it.id == dayEventId }
+                ?: error("DayEvent $dayEventId not found")
+            queries.insertEvent(
+                templateId,
+                source.title,
+                source.start_minute,
+                source.end_minute,
+                source.color,
+                source.notes,
+            )
+            val newId = queries.lastInsertedId().executeAsOne()
+            queries.deleteDayEvent(dayEventId)
+            newId
+        }
+    }
+
     suspend fun setNotificationsEnabled(enabled: Boolean) = withContext(ioDispatcher) {
         queries.updateNotificationsEnabled(if (enabled) 1L else 0L)
     }
@@ -169,6 +301,31 @@ class ScheduleRepository(
                     notes = it.notes,
                 )
             }.groupBy { it.templateId }
+            val dayEvents = queries.selectAllDayEvents().executeAsList().map { row ->
+                DayEvent(
+                    id = row.id,
+                    day = AppDayOfWeek.fromIso(row.day.toInt()),
+                    title = row.title,
+                    startMinute = row.start_minute.toInt(),
+                    endMinute = row.end_minute.toInt(),
+                    color = row.color,
+                    notes = row.notes,
+                )
+            }.groupBy { it.day }
+            val overrides = queries.selectAllOverrides().executeAsList().map { row ->
+                TemplateEventOverride(
+                    baseEventId = row.base_event_id,
+                    day = AppDayOfWeek.fromIso(row.day.toInt()),
+                    hidden = row.hidden != 0L,
+                    title = row.title,
+                    startMinute = row.start_minute?.toInt(),
+                    endMinute = row.end_minute?.toInt(),
+                    color = row.color,
+                    notes = row.notes,
+                )
+            }.groupBy { it.day }.mapValues { (_, list) ->
+                list.associateBy { it.baseEventId }
+            }
 
             ScheduleSnapshot(
                 settings = ScheduleSettings(
@@ -179,12 +336,16 @@ class ScheduleRepository(
                 templates = templates,
                 assignments = assignments,
                 eventsByTemplate = events,
+                dayEventsByDay = dayEvents,
+                overridesByDay = overrides,
             )
         }
     }
 
     suspend fun resetAll() = withContext(ioDispatcher) {
         database.transaction {
+            queries.deleteAllOverrides()
+            queries.deleteAllDayEvents()
             queries.deleteAllEvents()
             queries.deleteAllAssignments()
             queries.deleteAllTemplates()
@@ -200,6 +361,8 @@ class ScheduleRepository(
 
     suspend fun replaceAll(snapshot: ScheduleSnapshot) = withContext(ioDispatcher) {
         database.transaction {
+            queries.deleteAllOverrides()
+            queries.deleteAllDayEvents()
             queries.deleteAllEvents()
             queries.deleteAllAssignments()
             queries.deleteAllTemplates()
@@ -225,6 +388,29 @@ class ScheduleRepository(
                     e.endMinute.toLong(),
                     e.color,
                     e.notes,
+                )
+            }
+            snapshot.dayEventsByDay.values.flatten().forEach { e ->
+                queries.insertDayEventWithId(
+                    e.id,
+                    e.day.isoIndex.toLong(),
+                    e.title,
+                    e.startMinute.toLong(),
+                    e.endMinute.toLong(),
+                    e.color,
+                    e.notes,
+                )
+            }
+            snapshot.overridesByDay.values.flatMap { it.values }.forEach { ov ->
+                queries.upsertOverride(
+                    ov.baseEventId,
+                    ov.day.isoIndex.toLong(),
+                    if (ov.hidden) 1L else 0L,
+                    ov.title,
+                    ov.startMinute?.toLong(),
+                    ov.endMinute?.toLong(),
+                    ov.color,
+                    ov.notes,
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/domain/EffectiveEvent.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/domain/EffectiveEvent.kt
@@ -1,0 +1,68 @@
+package dev.nucleus.scheduleit.domain
+
+data class EffectiveEvent(
+    val day: AppDayOfWeek,
+    val title: String,
+    val startMinute: Int,
+    val endMinute: Int,
+    val color: Long,
+    val notes: String,
+    val source: Source,
+) {
+    sealed interface Source {
+        data class TemplateShared(val event: ScheduleEvent) : Source
+        data class TemplateOverridden(
+            val base: ScheduleEvent,
+            val override: TemplateEventOverride,
+        ) : Source
+        data class DayOnly(val event: DayEvent) : Source
+    }
+}
+
+fun ScheduleSnapshot.effectiveEventsFor(day: AppDayOfWeek): List<EffectiveEvent> {
+    val templateId = assignments[day]
+    val overrides = overridesByDay[day].orEmpty()
+
+    val fromTemplate: List<EffectiveEvent> = if (templateId == null) {
+        emptyList()
+    } else {
+        eventsByTemplate[templateId].orEmpty().mapNotNull { base ->
+            val override = overrides[base.id]
+            when {
+                override == null -> EffectiveEvent(
+                    day = day,
+                    title = base.title,
+                    startMinute = base.startMinute,
+                    endMinute = base.endMinute,
+                    color = base.color,
+                    notes = base.notes,
+                    source = EffectiveEvent.Source.TemplateShared(base),
+                )
+                override.hidden -> null
+                else -> EffectiveEvent(
+                    day = day,
+                    title = override.title ?: base.title,
+                    startMinute = override.startMinute ?: base.startMinute,
+                    endMinute = override.endMinute ?: base.endMinute,
+                    color = override.color ?: base.color,
+                    notes = override.notes ?: base.notes,
+                    source = EffectiveEvent.Source.TemplateOverridden(base, override),
+                )
+            }
+        }
+    }
+
+    val fromDay: List<EffectiveEvent> = dayEventsByDay[day].orEmpty().map { e ->
+        EffectiveEvent(
+            day = day,
+            title = e.title,
+            startMinute = e.startMinute,
+            endMinute = e.endMinute,
+            color = e.color,
+            notes = e.notes,
+            source = EffectiveEvent.Source.DayOnly(e),
+        )
+    }
+
+    return (fromTemplate + fromDay).sortedBy { it.startMinute }
+}

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/domain/Models.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/domain/Models.kt
@@ -51,11 +51,34 @@ data class ScheduleEvent(
     val notes: String,
 )
 
+data class DayEvent(
+    val id: Long,
+    val day: AppDayOfWeek,
+    val title: String,
+    val startMinute: Int,
+    val endMinute: Int,
+    val color: Long,
+    val notes: String,
+)
+
+data class TemplateEventOverride(
+    val baseEventId: Long,
+    val day: AppDayOfWeek,
+    val hidden: Boolean,
+    val title: String?,
+    val startMinute: Int?,
+    val endMinute: Int?,
+    val color: Long?,
+    val notes: String?,
+)
+
 data class ScheduleSnapshot(
     val settings: ScheduleSettings,
     val templates: List<DayTemplate>,
     val assignments: Map<AppDayOfWeek, Long>,
     val eventsByTemplate: Map<Long, List<ScheduleEvent>>,
+    val dayEventsByDay: Map<AppDayOfWeek, List<DayEvent>> = emptyMap(),
+    val overridesByDay: Map<AppDayOfWeek, Map<Long, TemplateEventOverride>> = emptyMap(),
 ) {
     val visibleDays: List<AppDayOfWeek>
         get() = AppDayOfWeek.entries.filter { it in assignments }

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/EditorBounds.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/EditorBounds.kt
@@ -1,5 +1,6 @@
 package dev.nucleus.scheduleit.presentation.schedule
 
+import dev.nucleus.scheduleit.domain.EffectiveEvent
 import dev.nucleus.scheduleit.domain.ScheduleEvent
 import dev.nucleus.scheduleit.domain.ScheduleSettings
 
@@ -12,10 +13,11 @@ data class EditorBounds(
 
 fun computeEditorBounds(
     draft: ScheduleEvent,
-    siblings: List<ScheduleEvent>,
+    siblings: List<EffectiveEvent>,
+    editing: EventEditorState.Original?,
     settings: ScheduleSettings,
 ): EditorBounds {
-    val others = siblings.filter { it.id != draft.id }
+    val others = siblings.filterNot { it.matchesOriginal(editing) }
     val prevEnd = others
         .filter { it.endMinute <= draft.startMinute }
         .maxOfOrNull { it.endMinute }
@@ -29,9 +31,24 @@ fun computeEditorBounds(
     return EditorBounds(lower, upper, lowerReason, upperReason)
 }
 
-fun ScheduleEvent.overlapsAnyOf(others: List<ScheduleEvent>): Boolean =
-    others.any { other ->
-        other.id != id &&
-            startMinute < other.endMinute &&
-            endMinute > other.startMinute
+fun ScheduleEvent.overlapsAnyOf(
+    siblings: List<EffectiveEvent>,
+    editing: EventEditorState.Original?,
+): Boolean {
+    val others = siblings.filterNot { it.matchesOriginal(editing) }
+    return others.any { other ->
+        startMinute < other.endMinute && endMinute > other.startMinute
     }
+}
+
+internal fun EffectiveEvent.matchesOriginal(original: EventEditorState.Original?): Boolean {
+    if (original == null) return false
+    return when (val s = source) {
+        is EffectiveEvent.Source.TemplateShared ->
+            original is EventEditorState.Original.TemplateEvent && s.event.id == original.event.id
+        is EffectiveEvent.Source.TemplateOverridden ->
+            original is EventEditorState.Original.Overridden && s.base.id == original.base.id
+        is EffectiveEvent.Source.DayOnly ->
+            original is EventEditorState.Original.DayOnly && s.event.id == original.event.id
+    }
+}

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleIntent.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleIntent.kt
@@ -1,6 +1,7 @@
 package dev.nucleus.scheduleit.presentation.schedule
 
 import dev.nucleus.scheduleit.domain.AppDayOfWeek
+import dev.nucleus.scheduleit.domain.EffectiveEvent
 import dev.nucleus.scheduleit.domain.ScheduleEvent
 
 sealed interface ScheduleIntent {
@@ -8,9 +9,11 @@ sealed interface ScheduleIntent {
     data object CloseSettings : ScheduleIntent
 
     data class RequestCreateEvent(val day: AppDayOfWeek, val startMinute: Int) : ScheduleIntent
-    data class RequestEditEvent(val event: ScheduleEvent) : ScheduleIntent
-    data class DeleteEvent(val id: Long) : ScheduleIntent
+    data class RequestEditEffectiveEvent(val effective: EffectiveEvent) : ScheduleIntent
+    data class DeleteEffectiveEvent(val effective: EffectiveEvent) : ScheduleIntent
+    data class HideEffectiveEvent(val effective: EffectiveEvent) : ScheduleIntent
     data class UpdateDraft(val draft: ScheduleEvent) : ScheduleIntent
+    data class SetEditorScope(val scope: EventEditorState.Scope) : ScheduleIntent
     data object DismissEditor : ScheduleIntent
     data object SaveEditor : ScheduleIntent
     data object DeleteEditor : ScheduleIntent

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleState.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleState.kt
@@ -1,9 +1,14 @@
 package dev.nucleus.scheduleit.presentation.schedule
 
 import dev.nucleus.scheduleit.domain.AppDayOfWeek
+import dev.nucleus.scheduleit.domain.DayEvent
 import dev.nucleus.scheduleit.domain.DayTemplate
+import dev.nucleus.scheduleit.domain.EffectiveEvent
 import dev.nucleus.scheduleit.domain.ScheduleEvent
 import dev.nucleus.scheduleit.domain.ScheduleSettings
+import dev.nucleus.scheduleit.domain.ScheduleSnapshot
+import dev.nucleus.scheduleit.domain.TemplateEventOverride
+import dev.nucleus.scheduleit.domain.effectiveEventsFor
 
 data class ScheduleUiState(
     val isLoading: Boolean = true,
@@ -11,21 +16,50 @@ data class ScheduleUiState(
     val templates: List<DayTemplate> = emptyList(),
     val assignments: Map<AppDayOfWeek, Long> = emptyMap(),
     val eventsByTemplate: Map<Long, List<ScheduleEvent>> = emptyMap(),
+    val dayEventsByDay: Map<AppDayOfWeek, List<DayEvent>> = emptyMap(),
+    val overridesByDay: Map<AppDayOfWeek, Map<Long, TemplateEventOverride>> = emptyMap(),
     val editor: EventEditorState? = null,
     val showSettings: Boolean = false,
     val errorMessage: ErrorKey? = null,
 ) {
     val visibleDays: List<AppDayOfWeek>
         get() = AppDayOfWeek.entries.filter { it in assignments }
+
+    fun effectiveEventsFor(day: AppDayOfWeek): List<EffectiveEvent> =
+        ScheduleSnapshot(
+            settings = settings,
+            templates = templates,
+            assignments = assignments,
+            eventsByTemplate = eventsByTemplate,
+            dayEventsByDay = dayEventsByDay,
+            overridesByDay = overridesByDay,
+        ).effectiveEventsFor(day)
+
+    fun isTemplateShared(templateId: Long): Boolean =
+        assignments.values.count { it == templateId } >= 2
 }
 
 data class EventEditorState(
     val mode: Mode,
+    val day: AppDayOfWeek,
     val templateId: Long,
-    val originDay: AppDayOfWeek,
     val draft: ScheduleEvent,
+    val scope: Scope,
+    val original: Original?,
+    val templateIsShared: Boolean,
 ) {
     enum class Mode { Create, Edit }
+
+    enum class Scope { ThisDayOnly, AllLinkedDays }
+
+    sealed interface Original {
+        data class TemplateEvent(val event: ScheduleEvent) : Original
+        data class DayOnly(val event: DayEvent) : Original
+        data class Overridden(
+            val base: ScheduleEvent,
+            val override: TemplateEventOverride,
+        ) : Original
+    }
 }
 
 enum class ErrorKey {

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleViewModel.kt
@@ -8,8 +8,11 @@ import dev.nucleus.scheduleit.data.encodeToString
 import dev.nucleus.scheduleit.data.toBackup
 import dev.nucleus.scheduleit.data.toSnapshot
 import dev.nucleus.scheduleit.domain.AppDayOfWeek
+import dev.nucleus.scheduleit.domain.DayEvent
+import dev.nucleus.scheduleit.domain.EffectiveEvent
 import dev.nucleus.scheduleit.domain.ScheduleEvent
 import dev.nucleus.scheduleit.domain.ScheduleSettings
+import dev.nucleus.scheduleit.domain.TemplateEventOverride
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.dialogs.openFilePicker
 import io.github.vinceglb.filekit.dialogs.openFileSaver
@@ -46,6 +49,8 @@ class ScheduleViewModel(
                         templates = snapshot.templates,
                         assignments = snapshot.assignments,
                         eventsByTemplate = snapshot.eventsByTemplate,
+                        dayEventsByDay = snapshot.dayEventsByDay,
+                        overridesByDay = snapshot.overridesByDay,
                     )
                 }
             }
@@ -58,10 +63,14 @@ class ScheduleViewModel(
             ScheduleIntent.CloseSettings -> _state.update { it.copy(showSettings = false) }
 
             is ScheduleIntent.RequestCreateEvent -> startCreate(intent.day, intent.startMinute)
-            is ScheduleIntent.RequestEditEvent -> startEdit(intent.event)
-            is ScheduleIntent.DeleteEvent -> viewModelScope.launch { repository.deleteEvent(intent.id) }
+            is ScheduleIntent.RequestEditEffectiveEvent -> startEdit(intent.effective)
+            is ScheduleIntent.DeleteEffectiveEvent -> deleteEffective(intent.effective)
+            is ScheduleIntent.HideEffectiveEvent -> hideEffective(intent.effective)
             is ScheduleIntent.UpdateDraft -> _state.update {
                 it.copy(editor = it.editor?.copy(draft = intent.draft))
+            }
+            is ScheduleIntent.SetEditorScope -> _state.update {
+                it.copy(editor = it.editor?.copy(scope = intent.scope))
             }
             ScheduleIntent.DismissEditor -> _state.update { it.copy(editor = null) }
             ScheduleIntent.SaveEditor -> saveEditor()
@@ -99,25 +108,48 @@ class ScheduleViewModel(
             it.copy(
                 editor = EventEditorState(
                     mode = EventEditorState.Mode.Create,
+                    day = day,
                     templateId = templateId,
-                    originDay = day,
                     draft = draft,
+                    scope = EventEditorState.Scope.ThisDayOnly,
+                    original = null,
+                    templateIsShared = current.isTemplateShared(templateId),
                 ),
             )
         }
     }
 
-    private fun startEdit(event: ScheduleEvent) {
+    private fun startEdit(effective: EffectiveEvent) {
         val current = _state.value
-        val originDay = current.assignments.entries.firstOrNull { it.value == event.templateId }?.key
-            ?: return
+        val day = effective.day
+        val templateId = current.assignments[day] ?: return
+        val (original, scope) = when (val s = effective.source) {
+            is EffectiveEvent.Source.TemplateShared ->
+                EventEditorState.Original.TemplateEvent(s.event) to EventEditorState.Scope.AllLinkedDays
+            is EffectiveEvent.Source.TemplateOverridden ->
+                EventEditorState.Original.Overridden(s.base, s.override) to EventEditorState.Scope.ThisDayOnly
+            is EffectiveEvent.Source.DayOnly ->
+                EventEditorState.Original.DayOnly(s.event) to EventEditorState.Scope.ThisDayOnly
+        }
+        val draft = ScheduleEvent(
+            id = 0L,
+            templateId = templateId,
+            title = effective.title,
+            startMinute = effective.startMinute,
+            endMinute = effective.endMinute,
+            color = effective.color,
+            notes = effective.notes,
+        )
         _state.update {
             it.copy(
                 editor = EventEditorState(
                     mode = EventEditorState.Mode.Edit,
-                    templateId = event.templateId,
-                    originDay = originDay,
-                    draft = event,
+                    day = day,
+                    templateId = templateId,
+                    draft = draft,
+                    scope = scope,
+                    original = original,
+                    templateIsShared = current.isTemplateShared(templateId),
                 ),
             )
         }
@@ -136,25 +168,168 @@ class ScheduleViewModel(
             _state.update { it.copy(errorMessage = ErrorKey.OutsideWindow) }
             return
         }
-        val siblings = current.eventsByTemplate[editor.templateId].orEmpty()
-        if (draft.overlapsAnyOf(siblings)) {
+        val sameDayConflict = draft.overlapsAnyOf(current.effectiveEventsFor(editor.day), editor.original)
+        if (sameDayConflict) {
             _state.update { it.copy(errorMessage = ErrorKey.Overlap) }
             return
         }
+        if (editor.scope == EventEditorState.Scope.AllLinkedDays && editor.templateIsShared) {
+            val otherDays = current.assignments.entries
+                .filter { it.value == editor.templateId && it.key != editor.day }
+                .map { it.key }
+            for (other in otherDays) {
+                if (draft.overlapsAnyOf(current.effectiveEventsFor(other), editor.original)) {
+                    _state.update { it.copy(errorMessage = ErrorKey.Overlap) }
+                    return
+                }
+            }
+        }
         viewModelScope.launch {
-            repository.upsertEvent(draft)
+            persistEditor(editor)
             _state.update { it.copy(editor = null) }
         }
     }
 
+    private suspend fun persistEditor(editor: EventEditorState) {
+        val draft = editor.draft
+        when (editor.scope) {
+            EventEditorState.Scope.ThisDayOnly -> when (val original = editor.original) {
+                null -> repository.upsertDayEvent(
+                    DayEvent(
+                        id = 0L,
+                        day = editor.day,
+                        title = draft.title,
+                        startMinute = draft.startMinute,
+                        endMinute = draft.endMinute,
+                        color = draft.color,
+                        notes = draft.notes,
+                    ),
+                )
+                is EventEditorState.Original.DayOnly -> repository.upsertDayEvent(
+                    DayEvent(
+                        id = original.event.id,
+                        day = editor.day,
+                        title = draft.title,
+                        startMinute = draft.startMinute,
+                        endMinute = draft.endMinute,
+                        color = draft.color,
+                        notes = draft.notes,
+                    ),
+                )
+                is EventEditorState.Original.TemplateEvent -> repository.upsertOverride(
+                    buildOverride(original.event, editor.day, draft),
+                )
+                is EventEditorState.Original.Overridden -> repository.upsertOverride(
+                    buildOverride(original.base, editor.day, draft),
+                )
+            }
+            EventEditorState.Scope.AllLinkedDays -> when (val original = editor.original) {
+                null -> repository.upsertEvent(
+                    ScheduleEvent(
+                        id = 0L,
+                        templateId = editor.templateId,
+                        title = draft.title,
+                        startMinute = draft.startMinute,
+                        endMinute = draft.endMinute,
+                        color = draft.color,
+                        notes = draft.notes,
+                    ),
+                )
+                is EventEditorState.Original.TemplateEvent -> repository.upsertEvent(
+                    ScheduleEvent(
+                        id = original.event.id,
+                        templateId = editor.templateId,
+                        title = draft.title,
+                        startMinute = draft.startMinute,
+                        endMinute = draft.endMinute,
+                        color = draft.color,
+                        notes = draft.notes,
+                    ),
+                )
+                is EventEditorState.Original.Overridden -> {
+                    repository.upsertEvent(
+                        ScheduleEvent(
+                            id = original.base.id,
+                            templateId = editor.templateId,
+                            title = draft.title,
+                            startMinute = draft.startMinute,
+                            endMinute = draft.endMinute,
+                            color = draft.color,
+                            notes = draft.notes,
+                        ),
+                    )
+                    repository.deleteOverride(original.base.id, editor.day)
+                }
+                is EventEditorState.Original.DayOnly -> {
+                    repository.upsertEvent(
+                        ScheduleEvent(
+                            id = 0L,
+                            templateId = editor.templateId,
+                            title = draft.title,
+                            startMinute = draft.startMinute,
+                            endMinute = draft.endMinute,
+                            color = draft.color,
+                            notes = draft.notes,
+                        ),
+                    )
+                    repository.deleteDayEvent(original.event.id)
+                }
+            }
+        }
+    }
+
+    private fun buildOverride(
+        base: ScheduleEvent,
+        day: AppDayOfWeek,
+        draft: ScheduleEvent,
+    ): TemplateEventOverride = TemplateEventOverride(
+        baseEventId = base.id,
+        day = day,
+        hidden = false,
+        title = draft.title.takeIf { it != base.title },
+        startMinute = draft.startMinute.takeIf { it != base.startMinute },
+        endMinute = draft.endMinute.takeIf { it != base.endMinute },
+        color = draft.color.takeIf { it != base.color },
+        notes = draft.notes.takeIf { it != base.notes },
+    )
+
     private fun deleteEditor() {
         val editor = _state.value.editor ?: return
-        if (editor.draft.id == 0L) {
+        val original = editor.original
+        if (original == null) {
             _state.update { it.copy(editor = null) }
             return
         }
         viewModelScope.launch {
-            repository.deleteEvent(editor.draft.id)
+            when (original) {
+                is EventEditorState.Original.TemplateEvent -> repository.deleteEvent(original.event.id)
+                is EventEditorState.Original.DayOnly -> repository.deleteDayEvent(original.event.id)
+                is EventEditorState.Original.Overridden -> repository.deleteOverride(original.base.id, editor.day)
+            }
+            _state.update { it.copy(editor = null) }
+        }
+    }
+
+    private fun deleteEffective(effective: EffectiveEvent) {
+        viewModelScope.launch {
+            when (val s = effective.source) {
+                is EffectiveEvent.Source.TemplateShared -> repository.deleteEvent(s.event.id)
+                is EffectiveEvent.Source.TemplateOverridden -> repository.deleteOverride(s.base.id, effective.day)
+                is EffectiveEvent.Source.DayOnly -> repository.deleteDayEvent(s.event.id)
+            }
+        }
+    }
+
+    private fun hideEffective(effective: EffectiveEvent) {
+        viewModelScope.launch {
+            when (val s = effective.source) {
+                is EffectiveEvent.Source.TemplateShared ->
+                    repository.hideTemplateEventForDay(s.event.id, effective.day)
+                is EffectiveEvent.Source.TemplateOverridden ->
+                    repository.upsertOverride(s.override.copy(hidden = true))
+                is EffectiveEvent.Source.DayOnly ->
+                    repository.deleteDayEvent(s.event.id)
+            }
             _state.update { it.copy(editor = null) }
         }
     }

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/ui/common/TimeGrid.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/ui/common/TimeGrid.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.nucleus.scheduleit.domain.AppDayOfWeek
-import dev.nucleus.scheduleit.domain.ScheduleEvent
+import dev.nucleus.scheduleit.domain.EffectiveEvent
 import dev.nucleus.scheduleit.presentation.schedule.ScheduleViewModel
 
 private const val SLOT_PER_HOUR = 60 / ScheduleViewModel.SLOT_MINUTES
@@ -49,10 +49,10 @@ fun TimeGrid(
     visibleDays: List<AppDayOfWeek>,
     startMinute: Int,
     endMinute: Int,
-    eventsForDay: (AppDayOfWeek) -> List<ScheduleEvent>,
+    eventsForDay: (AppDayOfWeek) -> List<EffectiveEvent>,
     dayHeader: @Composable (AppDayOfWeek) -> Unit,
     hourLabel: @Composable (hour: Int) -> Unit,
-    eventCell: @Composable (ScheduleEvent, AppDayOfWeek) -> Unit,
+    eventCell: @Composable (EffectiveEvent, AppDayOfWeek) -> Unit,
     onSlotClick: (AppDayOfWeek, startMinute: Int) -> Unit,
     backgroundColor: Color,
     modifier: Modifier = Modifier,
@@ -132,8 +132,8 @@ private fun DayColumn(
     hourHeight: Dp,
     gridLineColor: Color,
     slotHighlight: Color,
-    events: List<ScheduleEvent>,
-    eventCell: @Composable (ScheduleEvent) -> Unit,
+    events: List<EffectiveEvent>,
+    eventCell: @Composable (EffectiveEvent) -> Unit,
     onSlotClick: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/shared/src/commonMain/sqldelight/dev/nucleus/scheduleit/db/1.sqm
+++ b/shared/src/commonMain/sqldelight/dev/nucleus/scheduleit/db/1.sqm
@@ -1,0 +1,25 @@
+CREATE TABLE day_event (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    day INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    start_minute INTEGER NOT NULL,
+    end_minute INTEGER NOT NULL,
+    color INTEGER NOT NULL,
+    notes TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX day_event_day_idx ON day_event(day);
+
+CREATE TABLE template_event_override (
+    base_event_id INTEGER NOT NULL REFERENCES event(id) ON DELETE CASCADE,
+    day INTEGER NOT NULL,
+    hidden INTEGER NOT NULL DEFAULT 0,
+    title TEXT,
+    start_minute INTEGER,
+    end_minute INTEGER,
+    color INTEGER,
+    notes TEXT,
+    PRIMARY KEY (base_event_id, day)
+);
+
+CREATE INDEX template_event_override_day_idx ON template_event_override(day);

--- a/shared/src/commonMain/sqldelight/dev/nucleus/scheduleit/db/Schema.sq
+++ b/shared/src/commonMain/sqldelight/dev/nucleus/scheduleit/db/Schema.sq
@@ -31,6 +31,32 @@ CREATE TABLE event (
 
 CREATE INDEX event_template_idx ON event(template_id);
 
+CREATE TABLE day_event (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    day INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    start_minute INTEGER NOT NULL,
+    end_minute INTEGER NOT NULL,
+    color INTEGER NOT NULL,
+    notes TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX day_event_day_idx ON day_event(day);
+
+CREATE TABLE template_event_override (
+    base_event_id INTEGER NOT NULL REFERENCES event(id) ON DELETE CASCADE,
+    day INTEGER NOT NULL,
+    hidden INTEGER NOT NULL DEFAULT 0,
+    title TEXT,
+    start_minute INTEGER,
+    end_minute INTEGER,
+    color INTEGER,
+    notes TEXT,
+    PRIMARY KEY (base_event_id, day)
+);
+
+CREATE INDEX template_event_override_day_idx ON template_event_override(day);
+
 selectSettings:
 SELECT start_minute, end_minute, notifications_enabled FROM schedule_settings WHERE id = 1;
 
@@ -106,3 +132,48 @@ INSERT INTO day_template(id, name) VALUES (?, ?);
 insertEventWithId:
 INSERT INTO event(id, template_id, title, start_minute, end_minute, color, notes)
 VALUES (?, ?, ?, ?, ?, ?, ?);
+
+selectAllDayEvents:
+SELECT id, day, title, start_minute, end_minute, color, notes
+FROM day_event
+ORDER BY start_minute;
+
+insertDayEvent:
+INSERT INTO day_event(day, title, start_minute, end_minute, color, notes)
+VALUES (?, ?, ?, ?, ?, ?);
+
+insertDayEventWithId:
+INSERT INTO day_event(id, day, title, start_minute, end_minute, color, notes)
+VALUES (?, ?, ?, ?, ?, ?, ?);
+
+updateDayEvent:
+UPDATE day_event
+SET day = ?, title = ?, start_minute = ?, end_minute = ?, color = ?, notes = ?
+WHERE id = ?;
+
+deleteDayEvent:
+DELETE FROM day_event WHERE id = ?;
+
+deleteAllDayEvents:
+DELETE FROM day_event;
+
+selectAllOverrides:
+SELECT base_event_id, day, hidden, title, start_minute, end_minute, color, notes
+FROM template_event_override;
+
+upsertOverride:
+INSERT INTO template_event_override(base_event_id, day, hidden, title, start_minute, end_minute, color, notes)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(base_event_id, day) DO UPDATE SET
+    hidden = excluded.hidden,
+    title = excluded.title,
+    start_minute = excluded.start_minute,
+    end_minute = excluded.end_minute,
+    color = excluded.color,
+    notes = excluded.notes;
+
+deleteOverride:
+DELETE FROM template_event_override WHERE base_event_id = ? AND day = ?;
+
+deleteAllOverrides:
+DELETE FROM template_event_override;

--- a/shared/src/commonTest/kotlin/dev/nucleus/scheduleit/domain/EffectiveEventTest.kt
+++ b/shared/src/commonTest/kotlin/dev/nucleus/scheduleit/domain/EffectiveEventTest.kt
@@ -1,0 +1,121 @@
+package dev.nucleus.scheduleit.domain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class EffectiveEventTest {
+
+    private val settings = ScheduleSettings(startMinute = 8 * 60, endMinute = 20 * 60)
+    private val template = DayTemplate(id = 10L, name = "")
+    private val baseEvent = ScheduleEvent(
+        id = 100L,
+        templateId = template.id,
+        title = "Meeting",
+        startMinute = 9 * 60,
+        endMinute = 10 * 60,
+        color = 0xFF42A5F5L,
+        notes = "",
+    )
+
+    private fun snapshot(
+        dayEventsByDay: Map<AppDayOfWeek, List<DayEvent>> = emptyMap(),
+        overridesByDay: Map<AppDayOfWeek, Map<Long, TemplateEventOverride>> = emptyMap(),
+        events: List<ScheduleEvent> = listOf(baseEvent),
+        assignments: Map<AppDayOfWeek, Long> = mapOf(
+            AppDayOfWeek.Monday to template.id,
+            AppDayOfWeek.Thursday to template.id,
+        ),
+    ) = ScheduleSnapshot(
+        settings = settings,
+        templates = listOf(template),
+        assignments = assignments,
+        eventsByTemplate = events.groupBy { it.templateId },
+        dayEventsByDay = dayEventsByDay,
+        overridesByDay = overridesByDay,
+    )
+
+    @Test
+    fun shared_template_event_appears_on_both_days_unchanged() {
+        val s = snapshot()
+        val mon = s.effectiveEventsFor(AppDayOfWeek.Monday)
+        val thu = s.effectiveEventsFor(AppDayOfWeek.Thursday)
+        assertEquals(1, mon.size)
+        assertEquals(1, thu.size)
+        assertIs<EffectiveEvent.Source.TemplateShared>(mon.first().source)
+        assertIs<EffectiveEvent.Source.TemplateShared>(thu.first().source)
+        assertEquals("Meeting", mon.first().title)
+    }
+
+    @Test
+    fun override_changes_only_target_day() {
+        val s = snapshot(
+            overridesByDay = mapOf(
+                AppDayOfWeek.Monday to mapOf(
+                    baseEvent.id to TemplateEventOverride(
+                        baseEventId = baseEvent.id,
+                        day = AppDayOfWeek.Monday,
+                        hidden = false,
+                        title = "Standup",
+                        startMinute = null,
+                        endMinute = null,
+                        color = null,
+                        notes = null,
+                    ),
+                ),
+            ),
+        )
+        val mon = s.effectiveEventsFor(AppDayOfWeek.Monday)
+        val thu = s.effectiveEventsFor(AppDayOfWeek.Thursday)
+        assertEquals("Standup", mon.first().title)
+        assertIs<EffectiveEvent.Source.TemplateOverridden>(mon.first().source)
+        assertEquals(9 * 60, mon.first().startMinute)
+        assertEquals("Meeting", thu.first().title)
+        assertIs<EffectiveEvent.Source.TemplateShared>(thu.first().source)
+    }
+
+    @Test
+    fun hidden_override_removes_event_for_target_day_only() {
+        val s = snapshot(
+            overridesByDay = mapOf(
+                AppDayOfWeek.Thursday to mapOf(
+                    baseEvent.id to TemplateEventOverride(
+                        baseEventId = baseEvent.id,
+                        day = AppDayOfWeek.Thursday,
+                        hidden = true,
+                        title = null,
+                        startMinute = null,
+                        endMinute = null,
+                        color = null,
+                        notes = null,
+                    ),
+                ),
+            ),
+        )
+        assertTrue(s.effectiveEventsFor(AppDayOfWeek.Thursday).isEmpty())
+        assertEquals(1, s.effectiveEventsFor(AppDayOfWeek.Monday).size)
+    }
+
+    @Test
+    fun day_only_event_appears_only_on_its_day_and_is_sorted() {
+        val morning = DayEvent(
+            id = 200L,
+            day = AppDayOfWeek.Monday,
+            title = "Morning",
+            startMinute = 8 * 60,
+            endMinute = 9 * 60,
+            color = 0xFF66BB6AL,
+            notes = "",
+        )
+        val s = snapshot(
+            dayEventsByDay = mapOf(AppDayOfWeek.Monday to listOf(morning)),
+        )
+        val mon = s.effectiveEventsFor(AppDayOfWeek.Monday)
+        assertEquals(2, mon.size)
+        assertEquals("Morning", mon[0].title)
+        assertIs<EffectiveEvent.Source.DayOnly>(mon[0].source)
+        assertEquals("Meeting", mon[1].title)
+        assertTrue(s.effectiveEventsFor(AppDayOfWeek.Thursday).none { it.title == "Morning" })
+    }
+}

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelEventCell.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelEventCell.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import dev.nucleus.scheduleit.domain.ScheduleEvent
+import dev.nucleus.scheduleit.domain.EffectiveEvent
 import dev.nucleus.scheduleit.ui.common.formatTime
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.jewel.ui.component.Text
@@ -40,7 +40,7 @@ import scheduleit.shared.generated.resources.action_edit
 
 @Composable
 fun JewelEventCell(
-    event: ScheduleEvent,
+    event: EffectiveEvent,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
 ) {

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelEventEditor.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelEventEditor.kt
@@ -29,13 +29,14 @@ import androidx.compose.ui.window.rememberDialogState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import io.github.kdroidfilter.nucleus.window.jewel.JewelDecoratedDialog
 import io.github.kdroidfilter.nucleus.window.jewel.JewelDialogTitleBar
-import dev.nucleus.scheduleit.domain.ScheduleEvent
+import dev.nucleus.scheduleit.domain.EffectiveEvent
 import dev.nucleus.scheduleit.domain.ScheduleSettings
 import dev.nucleus.scheduleit.presentation.schedule.ErrorKey
 import dev.nucleus.scheduleit.presentation.schedule.EventEditorState
 import dev.nucleus.scheduleit.presentation.schedule.ScheduleIntent
 import dev.nucleus.scheduleit.presentation.schedule.ScheduleViewModel
 import dev.nucleus.scheduleit.presentation.schedule.computeEditorBounds
+import dev.nucleus.scheduleit.ui.common.fullName
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.DefaultButton
@@ -46,6 +47,7 @@ import org.jetbrains.jewel.ui.component.TextField
 import androidx.compose.foundation.shape.RoundedCornerShape
 import scheduleit.shared.generated.resources.Res
 import scheduleit.shared.generated.resources.action_cancel
+import scheduleit.shared.generated.resources.action_hide_for_day
 import scheduleit.shared.generated.resources.error_invalid_range
 import scheduleit.shared.generated.resources.error_outside_window
 import scheduleit.shared.generated.resources.error_overlap
@@ -58,6 +60,9 @@ import scheduleit.shared.generated.resources.event_field_end
 import scheduleit.shared.generated.resources.event_field_notes
 import scheduleit.shared.generated.resources.event_field_start
 import scheduleit.shared.generated.resources.event_field_title
+import scheduleit.shared.generated.resources.event_scope_all_days
+import scheduleit.shared.generated.resources.event_scope_label
+import scheduleit.shared.generated.resources.event_scope_this_day
 
 private val EVENT_COLORS = listOf(
     0xFF42A5F5L, 0xFFEF5350L, 0xFF66BB6AL, 0xFFFFCA28L,
@@ -68,12 +73,12 @@ private val EVENT_COLORS = listOf(
 fun JewelEventEditor(
     editor: EventEditorState,
     settings: ScheduleSettings,
-    siblings: List<ScheduleEvent>,
+    siblings: List<EffectiveEvent>,
     errorMessage: ErrorKey?,
     onIntent: (ScheduleIntent) -> Unit,
 ) {
     val draft = editor.draft
-    val bounds = computeEditorBounds(draft, siblings, settings)
+    val bounds = computeEditorBounds(draft, siblings, editor.original, settings)
     val state = rememberDialogState(size = DpSize(460.dp, 560.dp))
     val dialogTitle = stringResource(
         if (editor.mode == EventEditorState.Mode.Create) Res.string.event_dialog_new_title
@@ -92,6 +97,14 @@ fun JewelEventEditor(
                 .padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
+            if (editor.templateIsShared) {
+                ScopeSelector(
+                    dayLabel = editor.day.fullName(),
+                    scope = editor.scope,
+                    onScopeChange = { onIntent(ScheduleIntent.SetEditorScope(it)) },
+                )
+            }
+
             Text(stringResource(Res.string.event_field_title), color = JewelTheme.globalColors.text.info)
             TitleTextField(
                 value = draft.title,
@@ -168,6 +181,18 @@ fun JewelEventEditor(
                 horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = androidx.compose.ui.Alignment.End),
             ) {
                 if (editor.mode == EventEditorState.Mode.Edit) {
+                    val original = editor.original
+                    val canHide = editor.templateIsShared && (
+                        original is EventEditorState.Original.TemplateEvent ||
+                            original is EventEditorState.Original.Overridden
+                        )
+                    if (canHide) {
+                        OutlinedButton(
+                            onClick = { onIntent(ScheduleIntent.HideEffectiveEvent(editor.toEffective())) },
+                        ) {
+                            Text(stringResource(Res.string.action_hide_for_day, editor.day.fullName()))
+                        }
+                    }
                     OutlinedButton(onClick = { onIntent(ScheduleIntent.DeleteEditor) }) {
                         Text(stringResource(Res.string.action_delete))
                     }
@@ -257,5 +282,61 @@ private fun NotesTextArea(
     TextArea(
         state = state,
         modifier = Modifier.fillMaxWidth().height(96.dp),
+    )
+}
+
+@Composable
+private fun ScopeSelector(
+    dayLabel: String,
+    scope: EventEditorState.Scope,
+    onScopeChange: (EventEditorState.Scope) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(stringResource(Res.string.event_scope_label), color = JewelTheme.globalColors.text.info)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            val thisDay = EventEditorState.Scope.ThisDayOnly
+            val allDays = EventEditorState.Scope.AllLinkedDays
+            ScopeButton(
+                label = stringResource(Res.string.event_scope_this_day, dayLabel),
+                selected = scope == thisDay,
+                onClick = { onScopeChange(thisDay) },
+            )
+            ScopeButton(
+                label = stringResource(Res.string.event_scope_all_days),
+                selected = scope == allDays,
+                onClick = { onScopeChange(allDays) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScopeButton(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    if (selected) {
+        DefaultButton(onClick = onClick) { Text(label) }
+    } else {
+        OutlinedButton(onClick = onClick) { Text(label) }
+    }
+}
+
+private fun EventEditorState.toEffective(): EffectiveEvent {
+    val source: EffectiveEvent.Source = when (val o = original) {
+        is EventEditorState.Original.TemplateEvent -> EffectiveEvent.Source.TemplateShared(o.event)
+        is EventEditorState.Original.Overridden -> EffectiveEvent.Source.TemplateOverridden(o.base, o.override)
+        is EventEditorState.Original.DayOnly -> EffectiveEvent.Source.DayOnly(o.event)
+        null -> error("Editor without original cannot be hidden")
+    }
+    return EffectiveEvent(
+        day = day,
+        title = draft.title,
+        startMinute = draft.startMinute,
+        endMinute = draft.endMinute,
+        color = draft.color,
+        notes = draft.notes,
+        source = source,
     )
 }

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelScheduleHost.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelScheduleHost.kt
@@ -45,17 +45,14 @@ fun JewelScheduleHost() {
                 visibleDays = visibleDays,
                 startMinute = state.settings.startMinute,
                 endMinute = state.settings.endMinute,
-                eventsForDay = { day ->
-                    val tpl = state.assignments[day] ?: return@TimeGrid emptyList()
-                    state.eventsByTemplate[tpl].orEmpty()
-                },
+                eventsForDay = { day -> state.effectiveEventsFor(day) },
                 dayHeader = { day -> Text(day.fullName()) },
                 hourLabel = { hour -> Text(dev.nucleus.scheduleit.ui.common.formatHourLabel(hour)) },
                 eventCell = { event, _ ->
                     JewelEventCell(
                         event = event,
-                        onEdit = { viewModel.onEvent(ScheduleIntent.RequestEditEvent(event)) },
-                        onDelete = { viewModel.onEvent(ScheduleIntent.DeleteEvent(event.id)) },
+                        onEdit = { viewModel.onEvent(ScheduleIntent.RequestEditEffectiveEvent(event)) },
+                        onDelete = { viewModel.onEvent(ScheduleIntent.DeleteEffectiveEvent(event)) },
                     )
                 },
                 onSlotClick = { day, minute ->
@@ -75,7 +72,7 @@ fun JewelScheduleHost() {
         JewelEventEditor(
             editor = editor,
             settings = state.settings,
-            siblings = state.eventsByTemplate[editor.templateId].orEmpty(),
+            siblings = state.effectiveEventsFor(editor.day),
             errorMessage = state.errorMessage,
             onIntent = viewModel::onEvent,
         )

--- a/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/material3/MaterialEventEditor.kt
+++ b/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/material3/MaterialEventEditor.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -20,17 +21,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import dev.nucleus.scheduleit.domain.ScheduleEvent
+import dev.nucleus.scheduleit.domain.EffectiveEvent
 import dev.nucleus.scheduleit.domain.ScheduleSettings
 import dev.nucleus.scheduleit.presentation.schedule.ErrorKey
 import dev.nucleus.scheduleit.presentation.schedule.EventEditorState
 import dev.nucleus.scheduleit.presentation.schedule.ScheduleIntent
 import dev.nucleus.scheduleit.presentation.schedule.ScheduleViewModel
 import dev.nucleus.scheduleit.presentation.schedule.computeEditorBounds
+import dev.nucleus.scheduleit.ui.common.fullName
 import org.jetbrains.compose.resources.stringResource
 import scheduleit.shared.generated.resources.Res
 import scheduleit.shared.generated.resources.action_cancel
 import scheduleit.shared.generated.resources.action_delete
+import scheduleit.shared.generated.resources.action_hide_for_day
 import scheduleit.shared.generated.resources.action_save
 import scheduleit.shared.generated.resources.event_dialog_edit_title
 import scheduleit.shared.generated.resources.event_dialog_new_title
@@ -39,6 +42,9 @@ import scheduleit.shared.generated.resources.event_field_end
 import scheduleit.shared.generated.resources.event_field_notes
 import scheduleit.shared.generated.resources.event_field_start
 import scheduleit.shared.generated.resources.event_field_title
+import scheduleit.shared.generated.resources.event_scope_all_days
+import scheduleit.shared.generated.resources.event_scope_label
+import scheduleit.shared.generated.resources.event_scope_this_day
 
 private val EVENT_COLORS = listOf(
     0xFF42A5F5L, 0xFFEF5350L, 0xFF66BB6AL, 0xFFFFCA28L,
@@ -50,11 +56,11 @@ private val EVENT_COLORS = listOf(
 fun MaterialEventEditor(
     editor: EventEditorState,
     settings: ScheduleSettings,
-    siblings: List<ScheduleEvent>,
+    siblings: List<EffectiveEvent>,
     onIntent: (ScheduleIntent) -> Unit,
 ) {
     val draft = editor.draft
-    val bounds = computeEditorBounds(draft, siblings, settings)
+    val bounds = computeEditorBounds(draft, siblings, editor.original, settings)
     AlertDialog(
         onDismissRequest = { onIntent(ScheduleIntent.DismissEditor) },
         title = {
@@ -72,6 +78,14 @@ fun MaterialEventEditor(
             androidx.compose.foundation.layout.Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
+                if (editor.templateIsShared) {
+                    MaterialScopeSelector(
+                        dayLabel = editor.day.fullName(),
+                        scope = editor.scope,
+                        onScopeChange = { onIntent(ScheduleIntent.SetEditorScope(it)) },
+                    )
+                }
+
                 MaterialStableTextField(
                     value = draft.title,
                     onValueChange = { onIntent(ScheduleIntent.UpdateDraft(draft.copy(title = it))) },
@@ -152,6 +166,18 @@ fun MaterialEventEditor(
         dismissButton = {
             Row {
                 if (editor.mode == EventEditorState.Mode.Edit) {
+                    val original = editor.original
+                    val canHide = editor.templateIsShared && (
+                        original is EventEditorState.Original.TemplateEvent ||
+                            original is EventEditorState.Original.Overridden
+                        )
+                    if (canHide) {
+                        TextButton(
+                            onClick = { onIntent(ScheduleIntent.HideEffectiveEvent(editor.toEffective())) },
+                        ) {
+                            Text(stringResource(Res.string.action_hide_for_day, editor.day.fullName()))
+                        }
+                    }
                     TextButton(onClick = { onIntent(ScheduleIntent.DeleteEditor) }) {
                         Text(stringResource(Res.string.action_delete))
                     }
@@ -161,5 +187,52 @@ fun MaterialEventEditor(
                 }
             }
         },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MaterialScopeSelector(
+    dayLabel: String,
+    scope: EventEditorState.Scope,
+    onScopeChange: (EventEditorState.Scope) -> Unit,
+) {
+    androidx.compose.foundation.layout.Column(
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = stringResource(Res.string.event_scope_label),
+            style = MaterialTheme.typography.labelMedium,
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(
+                selected = scope == EventEditorState.Scope.ThisDayOnly,
+                onClick = { onScopeChange(EventEditorState.Scope.ThisDayOnly) },
+                label = { Text(stringResource(Res.string.event_scope_this_day, dayLabel)) },
+            )
+            FilterChip(
+                selected = scope == EventEditorState.Scope.AllLinkedDays,
+                onClick = { onScopeChange(EventEditorState.Scope.AllLinkedDays) },
+                label = { Text(stringResource(Res.string.event_scope_all_days)) },
+            )
+        }
+    }
+}
+
+private fun EventEditorState.toEffective(): EffectiveEvent {
+    val source: EffectiveEvent.Source = when (val o = original) {
+        is EventEditorState.Original.TemplateEvent -> EffectiveEvent.Source.TemplateShared(o.event)
+        is EventEditorState.Original.Overridden -> EffectiveEvent.Source.TemplateOverridden(o.base, o.override)
+        is EventEditorState.Original.DayOnly -> EffectiveEvent.Source.DayOnly(o.event)
+        null -> error("Editor without original cannot be hidden")
+    }
+    return EffectiveEvent(
+        day = day,
+        title = draft.title,
+        startMinute = draft.startMinute,
+        endMinute = draft.endMinute,
+        color = draft.color,
+        notes = draft.notes,
+        source = source,
     )
 }

--- a/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/material3/MaterialScheduleHost.kt
+++ b/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/material3/MaterialScheduleHost.kt
@@ -101,10 +101,7 @@ fun MaterialScheduleHost() {
                     visibleDays = visibleDays,
                     startMinute = state.settings.startMinute,
                     endMinute = state.settings.endMinute,
-                    eventsForDay = { day ->
-                        val tpl = state.assignments[day] ?: return@TimeGrid emptyList()
-                        state.eventsByTemplate[tpl].orEmpty()
-                    },
+                    eventsForDay = { day -> state.effectiveEventsFor(day) },
                     dayHeader = { day ->
                         Text(
                             text = day.fullName(),
@@ -126,7 +123,7 @@ fun MaterialScheduleHost() {
                             tonalElevation = 2.dp,
                             modifier = Modifier
                                 .fillMaxSize()
-                                .clickable { viewModel.onEvent(ScheduleIntent.RequestEditEvent(event)) },
+                                .clickable { viewModel.onEvent(ScheduleIntent.RequestEditEffectiveEvent(event)) },
                         ) {
                             Box(modifier = Modifier.padding(horizontal = 6.dp, vertical = 4.dp)) {
                                 Text(
@@ -158,7 +155,7 @@ fun MaterialScheduleHost() {
         MaterialEventEditor(
             editor = editor,
             settings = state.settings,
-            siblings = state.eventsByTemplate[editor.templateId].orEmpty(),
+            siblings = state.effectiveEventsFor(editor.day),
             onIntent = viewModel::onEvent,
         )
     }


### PR DESCRIPTION
## Summary
- Lets you add, hide, or override an event for a single day, even when the template is shared across multiple days.
- Introduces two new tables (`day_event`, `template_event_override`) with SQLDelight v2 migration and an `EffectiveEvent` type that unifies rendering for the UI and notifications.
- Extends the ViewModel with a scope toggle ("Only [Day]" / "All linked days") and a "Hide for [Day]" button.

## Test plan
- [x] `./gradlew :shared:allTests` (unit tests `EffectiveEventTest`)
- [x] `./gradlew :shared:build :desktopApp:build`
- [x] Run `./gradlew :desktopApp:run`, link two days to the same template, and verify:
  - [x] Creating an "Only [Day]" event → invisible on the other day
  - [x] Toggling to "All linked days" → propagates to the template
  - [x] Editing a shared event in "Only [Day]" mode → override applied only on that day
  - [x] "Hide for [Day]" → the event stays visible on the other linked day
  - [x] JSON export/import preserves `dayEvents` and `overrides` (backup v2)
  - [x] Notifications respect overrides and hides
  - [x] Reset data also clears `day_event` and `template_event_override`