### PR TITLE
Copy/paste events via context menu

### DIFF
--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -17,6 +17,8 @@
     <string name="action_add_event">Ajouter un événement</string>
     <string name="action_edit">Modifier</string>
     <string name="action_delete_event">Supprimer l&#8217;événement</string>
+    <string name="action_copy_event">Copier l&#8217;événement</string>
+    <string name="action_paste_event">Coller l&#8217;événement</string>
     <string name="action_step_up">Augmenter</string>
     <string name="action_step_down">Diminuer</string>
 

--- a/shared/src/commonMain/composeResources/values-he/strings.xml
+++ b/shared/src/commonMain/composeResources/values-he/strings.xml
@@ -17,6 +17,8 @@
     <string name="action_add_event">הוסף אירוע</string>
     <string name="action_edit">ערוך</string>
     <string name="action_delete_event">מחק אירוע</string>
+    <string name="action_copy_event">העתק אירוע</string>
+    <string name="action_paste_event">הדבק אירוע</string>
     <string name="action_step_up">הגדל</string>
     <string name="action_step_down">הקטן</string>
 

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="action_add_event">Add event</string>
     <string name="action_edit">Edit</string>
     <string name="action_delete_event">Delete event</string>
+    <string name="action_copy_event">Copy event</string>
+    <string name="action_paste_event">Paste event</string>
     <string name="action_step_up">Increase</string>
     <string name="action_step_down">Decrease</string>
 

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleIntent.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleIntent.kt
@@ -12,6 +12,8 @@ sealed interface ScheduleIntent {
     data class RequestEditEffectiveEvent(val effective: EffectiveEvent) : ScheduleIntent
     data class DeleteEffectiveEvent(val effective: EffectiveEvent) : ScheduleIntent
     data class HideEffectiveEvent(val effective: EffectiveEvent) : ScheduleIntent
+    data class CopyEvent(val effective: EffectiveEvent) : ScheduleIntent
+    data class PasteEventAt(val day: AppDayOfWeek, val startMinute: Int) : ScheduleIntent
     data class UpdateDraft(val draft: ScheduleEvent) : ScheduleIntent
     data class SetEditorScope(val scope: EventEditorState.Scope) : ScheduleIntent
     data object DismissEditor : ScheduleIntent

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleState.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleState.kt
@@ -21,6 +21,7 @@ data class ScheduleUiState(
     val editor: EventEditorState? = null,
     val showSettings: Boolean = false,
     val errorMessage: ErrorKey? = null,
+    val clipboard: ClipboardEvent? = null,
 ) {
     val visibleDays: List<AppDayOfWeek>
         get() = AppDayOfWeek.entries.filter { it in assignments }
@@ -61,6 +62,13 @@ data class EventEditorState(
         ) : Original
     }
 }
+
+data class ClipboardEvent(
+    val title: String,
+    val color: Long,
+    val notes: String,
+    val durationMinutes: Int,
+)
 
 enum class ErrorKey {
     InvalidRange,

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleViewModel.kt
@@ -66,6 +66,8 @@ class ScheduleViewModel(
             is ScheduleIntent.RequestEditEffectiveEvent -> startEdit(intent.effective)
             is ScheduleIntent.DeleteEffectiveEvent -> deleteEffective(intent.effective)
             is ScheduleIntent.HideEffectiveEvent -> hideEffective(intent.effective)
+            is ScheduleIntent.CopyEvent -> copyEvent(intent.effective)
+            is ScheduleIntent.PasteEventAt -> pasteAt(intent.day, intent.startMinute)
             is ScheduleIntent.UpdateDraft -> _state.update {
                 it.copy(editor = it.editor?.copy(draft = intent.draft))
             }
@@ -331,6 +333,58 @@ class ScheduleViewModel(
                     repository.deleteDayEvent(s.event.id)
             }
             _state.update { it.copy(editor = null) }
+        }
+    }
+
+    private fun copyEvent(effective: EffectiveEvent) {
+        _state.update {
+            it.copy(
+                clipboard = ClipboardEvent(
+                    title = effective.title,
+                    color = effective.color,
+                    notes = effective.notes,
+                    durationMinutes = effective.endMinute - effective.startMinute,
+                ),
+            )
+        }
+    }
+
+    private fun pasteAt(day: AppDayOfWeek, startMinute: Int) {
+        val current = _state.value
+        val clipboard = current.clipboard ?: return
+        val window = current.settings
+        val snapped = (startMinute / SLOT_MINUTES) * SLOT_MINUTES
+        val start = snapped.coerceAtLeast(window.startMinute)
+        val end = start + clipboard.durationMinutes
+        if (end > window.endMinute) {
+            _state.update { it.copy(errorMessage = ErrorKey.OutsideWindow) }
+            return
+        }
+        val draft = ScheduleEvent(
+            id = 0L,
+            templateId = current.assignments[day] ?: 0L,
+            title = clipboard.title,
+            startMinute = start,
+            endMinute = end,
+            color = clipboard.color,
+            notes = clipboard.notes,
+        )
+        if (draft.overlapsAnyOf(current.effectiveEventsFor(day), editing = null)) {
+            _state.update { it.copy(errorMessage = ErrorKey.Overlap) }
+            return
+        }
+        viewModelScope.launch {
+            repository.upsertDayEvent(
+                DayEvent(
+                    id = 0L,
+                    day = day,
+                    title = clipboard.title,
+                    startMinute = start,
+                    endMinute = end,
+                    color = clipboard.color,
+                    notes = clipboard.notes,
+                ),
+            )
         }
     }
 

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/ui/common/SlotContextMenu.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/ui/common/SlotContextMenu.kt
@@ -6,5 +6,7 @@ import androidx.compose.runtime.Composable
 expect fun SlotContextMenuArea(
     addEventLabel: String,
     onAddEvent: () -> Unit,
-    content: @Composable () -> Unit,
+    pasteEventLabel: String?,
+    onPasteEvent: (() -> Unit)?,
+    content: @Composable (onLongPress: (() -> Unit)?) -> Unit,
 )

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/ui/common/TimeGrid.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/ui/common/TimeGrid.kt
@@ -1,7 +1,9 @@
+@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+
 package dev.nucleus.scheduleit.ui.common
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -57,6 +59,8 @@ fun TimeGrid(
     backgroundColor: Color,
     modifier: Modifier = Modifier,
     dimensions: TimeGridDimensions = TimeGridDimensions(),
+    pasteEventLabel: String? = null,
+    onSlotPaste: ((AppDayOfWeek, startMinute: Int) -> Unit)? = null,
 ) {
     val hours = remember(startMinute, endMinute) {
         val first = startMinute / 60
@@ -97,6 +101,8 @@ fun TimeGrid(
                         events = eventsForDay(day),
                         eventCell = { event -> eventCell(event, day) },
                         onSlotClick = { minute -> onSlotClick(day, minute) },
+                        pasteEventLabel = pasteEventLabel,
+                        onSlotPaste = onSlotPaste?.let { paste -> { minute -> paste(day, minute) } },
                         modifier = Modifier.weight(1f),
                     )
                 }
@@ -135,6 +141,8 @@ private fun DayColumn(
     events: List<EffectiveEvent>,
     eventCell: @Composable (EffectiveEvent) -> Unit,
     onSlotClick: (Int) -> Unit,
+    pasteEventLabel: String?,
+    onSlotPaste: ((Int) -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     val density = LocalDensity.current
@@ -163,6 +171,8 @@ private fun DayColumn(
                             gridLineColor = gridLineColor,
                             slotHighlight = slotHighlight,
                             onSlotClick = onSlotClick,
+                            pasteEventLabel = pasteEventLabel,
+                            onSlotPaste = onSlotPaste,
                         )
                     }
                 }
@@ -193,6 +203,8 @@ private fun HoverableSlot(
     gridLineColor: Color,
     slotHighlight: Color,
     onSlotClick: (Int) -> Unit,
+    pasteEventLabel: String?,
+    onSlotPaste: ((Int) -> Unit)?,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isHovered by interactionSource.collectIsHoveredAsState()
@@ -201,7 +213,9 @@ private fun HoverableSlot(
     SlotContextMenuArea(
         addEventLabel = addEventLabel,
         onAddEvent = { onSlotClick(slotStart) },
-    ) {
+        pasteEventLabel = pasteEventLabel,
+        onPasteEvent = onSlotPaste?.let { paste -> { paste(slotStart) } },
+    ) { onLongPress ->
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -209,7 +223,12 @@ private fun HoverableSlot(
                 .background(hoverBg)
                 .hoverable(interactionSource)
                 .pointerHoverIcon(PointerIcon.Hand)
-                .clickable(interactionSource = interactionSource, indication = null) { onSlotClick(slotStart) },
+                .combinedClickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = { onSlotClick(slotStart) },
+                    onLongClick = onLongPress,
+                ),
         ) {
             if (slotIdx == 0) {
                 Box(

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/common/SlotContextMenu.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/common/SlotContextMenu.jvm.kt
@@ -10,10 +10,19 @@ import androidx.compose.runtime.Composable
 actual fun SlotContextMenuArea(
     addEventLabel: String,
     onAddEvent: () -> Unit,
-    content: @Composable () -> Unit,
+    pasteEventLabel: String?,
+    onPasteEvent: (() -> Unit)?,
+    content: @Composable (onLongPress: (() -> Unit)?) -> Unit,
 ) {
     ContextMenuArea(
-        items = { listOf(ContextMenuItem(addEventLabel, onAddEvent)) },
-        content = content,
+        items = {
+            buildList {
+                add(ContextMenuItem(addEventLabel, onAddEvent))
+                if (pasteEventLabel != null && onPasteEvent != null) {
+                    add(ContextMenuItem(pasteEventLabel, onPasteEvent))
+                }
+            }
+        },
+        content = { content(null) },
     )
 }

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelEventCell.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelEventCell.kt
@@ -35,6 +35,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.Tooltip
 import scheduleit.shared.generated.resources.Res
+import scheduleit.shared.generated.resources.action_copy_event
 import scheduleit.shared.generated.resources.action_delete_event
 import scheduleit.shared.generated.resources.action_edit
 
@@ -42,6 +43,7 @@ import scheduleit.shared.generated.resources.action_edit
 fun JewelEventCell(
     event: EffectiveEvent,
     onEdit: () -> Unit,
+    onCopy: () -> Unit,
     onDelete: () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -49,6 +51,7 @@ fun JewelEventCell(
     val baseColor = Color(event.color.toInt())
     val shape = RoundedCornerShape(6.dp)
     val editLabel = stringResource(Res.string.action_edit)
+    val copyLabel = stringResource(Res.string.action_copy_event)
     val deleteLabel = stringResource(Res.string.action_delete_event)
     val menuState = remember { ContextMenuState() }
     val isMenuOpen = menuState.status is ContextMenuState.Status.Open
@@ -57,6 +60,7 @@ fun JewelEventCell(
         items = {
             listOf(
                 ContextMenuItem(editLabel, onEdit),
+                ContextMenuItem(copyLabel, onCopy),
                 ContextMenuItem(deleteLabel, onDelete),
             )
         },

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelScheduleHost.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelScheduleHost.kt
@@ -22,6 +22,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.Text
 import scheduleit.shared.generated.resources.Res
+import scheduleit.shared.generated.resources.action_paste_event
 import scheduleit.shared.generated.resources.empty_schedule_hint
 
 @Composable
@@ -30,6 +31,7 @@ fun JewelScheduleHost() {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     val visibleDays = localizedWeekOrder().filter { it in state.assignments }
+    val pasteLabel = stringResource(Res.string.action_paste_event)
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (visibleDays.isEmpty()) {
@@ -52,6 +54,7 @@ fun JewelScheduleHost() {
                     JewelEventCell(
                         event = event,
                         onEdit = { viewModel.onEvent(ScheduleIntent.RequestEditEffectiveEvent(event)) },
+                        onCopy = { viewModel.onEvent(ScheduleIntent.CopyEvent(event)) },
                         onDelete = { viewModel.onEvent(ScheduleIntent.DeleteEffectiveEvent(event)) },
                     )
                 },
@@ -64,6 +67,10 @@ fun JewelScheduleHost() {
                     gridLineColor = JewelTheme.globalColors.borders.normal,
                     slotHighlight = JewelTheme.globalColors.borders.disabled,
                 ),
+                pasteEventLabel = state.clipboard?.let { pasteLabel },
+                onSlotPaste = state.clipboard?.let {
+                    { day, minute -> viewModel.onEvent(ScheduleIntent.PasteEventAt(day, minute)) }
+                },
             )
         }
     }

--- a/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/common/SlotContextMenu.nonJvm.kt
+++ b/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/common/SlotContextMenu.nonJvm.kt
@@ -1,12 +1,46 @@
 package dev.nucleus.scheduleit.ui.common
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 
 @Composable
 actual fun SlotContextMenuArea(
     addEventLabel: String,
     onAddEvent: () -> Unit,
-    content: @Composable () -> Unit,
+    pasteEventLabel: String?,
+    onPasteEvent: (() -> Unit)?,
+    content: @Composable (onLongPress: (() -> Unit)?) -> Unit,
 ) {
-    content()
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        content { expanded = true }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text(addEventLabel) },
+                onClick = {
+                    expanded = false
+                    onAddEvent()
+                },
+            )
+            if (pasteEventLabel != null && onPasteEvent != null) {
+                DropdownMenuItem(
+                    text = { Text(pasteEventLabel) },
+                    onClick = {
+                        expanded = false
+                        onPasteEvent()
+                    },
+                )
+            }
+        }
+    }
 }

--- a/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/material3/MaterialEventCell.kt
+++ b/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/material3/MaterialEventCell.kt
@@ -1,0 +1,92 @@
+@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+
+package dev.nucleus.scheduleit.ui.material3
+
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.nucleus.scheduleit.domain.EffectiveEvent
+import org.jetbrains.compose.resources.stringResource
+import scheduleit.shared.generated.resources.Res
+import scheduleit.shared.generated.resources.action_copy_event
+import scheduleit.shared.generated.resources.action_delete_event
+import scheduleit.shared.generated.resources.action_edit
+
+@Composable
+fun MaterialEventCell(
+    event: EffectiveEvent,
+    onEdit: () -> Unit,
+    onCopy: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    val editLabel = stringResource(Res.string.action_edit)
+    val copyLabel = stringResource(Res.string.action_copy_event)
+    val deleteLabel = stringResource(Res.string.action_delete_event)
+
+    Surface(
+        color = Color(event.color.toInt()),
+        contentColor = Color.White,
+        shape = RoundedCornerShape(8.dp),
+        tonalElevation = 2.dp,
+        modifier = Modifier
+            .fillMaxSize()
+            .combinedClickable(
+                onClick = onEdit,
+                onLongClick = { menuOpen = true },
+            ),
+    ) {
+        Box(modifier = Modifier.padding(horizontal = 6.dp, vertical = 4.dp)) {
+            Text(
+                text = event.title.ifEmpty { "—" },
+                style = MaterialTheme.typography.labelMedium,
+                color = Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                softWrap = false,
+            )
+            DropdownMenu(
+                expanded = menuOpen,
+                onDismissRequest = { menuOpen = false },
+            ) {
+                DropdownMenuItem(
+                    text = { Text(editLabel) },
+                    onClick = {
+                        menuOpen = false
+                        onEdit()
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text(copyLabel) },
+                    onClick = {
+                        menuOpen = false
+                        onCopy()
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text(deleteLabel) },
+                    onClick = {
+                        menuOpen = false
+                        onDelete()
+                    },
+                )
+            }
+        }
+    }
+}

--- a/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/material3/MaterialScheduleHost.kt
+++ b/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/material3/MaterialScheduleHost.kt
@@ -1,6 +1,5 @@
 package dev.nucleus.scheduleit.ui.material3
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -8,7 +7,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TextButton
@@ -16,7 +14,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -24,7 +21,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.nucleus.scheduleit.presentation.schedule.ErrorKey
@@ -37,6 +33,7 @@ import dev.zacsweers.metrox.viewmodel.metroViewModel
 import org.jetbrains.compose.resources.stringResource
 import scheduleit.shared.generated.resources.Res
 import scheduleit.shared.generated.resources.action_open_settings
+import scheduleit.shared.generated.resources.action_paste_event
 import scheduleit.shared.generated.resources.empty_schedule_hint
 import scheduleit.shared.generated.resources.error_invalid_backup
 import scheduleit.shared.generated.resources.error_invalid_range
@@ -51,6 +48,7 @@ fun MaterialScheduleHost() {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbar = remember { SnackbarHostState() }
     val visibleDays = localizedWeekOrder().filter { it in state.assignments }
+    val pasteLabel = stringResource(Res.string.action_paste_event)
 
     val invalidRangeText = stringResource(Res.string.error_invalid_range)
     val outsideWindowText = stringResource(Res.string.error_outside_window)
@@ -116,26 +114,12 @@ fun MaterialScheduleHost() {
                         )
                     },
                     eventCell = { event, _ ->
-                        Surface(
-                            color = Color(event.color.toInt()),
-                            contentColor = Color.White,
-                            shape = RoundedCornerShape(8.dp),
-                            tonalElevation = 2.dp,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .clickable { viewModel.onEvent(ScheduleIntent.RequestEditEffectiveEvent(event)) },
-                        ) {
-                            Box(modifier = Modifier.padding(horizontal = 6.dp, vertical = 4.dp)) {
-                                Text(
-                                    text = event.title.ifEmpty { "—" },
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = Color.White,
-                                    maxLines = 1,
-                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                                    softWrap = false,
-                                )
-                            }
-                        }
+                        MaterialEventCell(
+                            event = event,
+                            onEdit = { viewModel.onEvent(ScheduleIntent.RequestEditEffectiveEvent(event)) },
+                            onCopy = { viewModel.onEvent(ScheduleIntent.CopyEvent(event)) },
+                            onDelete = { viewModel.onEvent(ScheduleIntent.DeleteEffectiveEvent(event)) },
+                        )
                     },
                     onSlotClick = { day, minute ->
                         viewModel.onEvent(ScheduleIntent.RequestCreateEvent(day, minute))
@@ -146,6 +130,10 @@ fun MaterialScheduleHost() {
                         gridLineColor = MaterialTheme.colorScheme.outline,
                         slotHighlight = MaterialTheme.colorScheme.outlineVariant,
                     ),
+                    pasteEventLabel = state.clipboard?.let { pasteLabel },
+                    onSlotPaste = state.clipboard?.let {
+                        { day, minute -> viewModel.onEvent(ScheduleIntent.PasteEventAt(day, minute)) }
+                    },
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Right-click (Jewel/desktop) or long-press (Material/mobile) on an event → "Copy event" entry.
- Right-click / long-press on an empty slot → "Paste event" entry (only visible when the clipboard holds something).
- Pasting creates a DayOnly event directly at the clicked slot, preserving title / duration / color / notes; snackbar error if the duration overflows the window or overlaps another event.

## Implementation
- `ClipboardEvent` added to `ScheduleUiState` (transient, not persisted).
- Two new intents: `CopyEvent` and `PasteEventAt`. Validation via the existing `overlapsAnyOf`.
- `SlotContextMenuArea`: extended signature with optional `pasteEventLabel` / `onPasteEvent` and an `onLongPress` exposed to the content.
  - JVM still uses `ContextMenuArea` (right-click).
  - nonJvm switches from a no-op to a wrapper that displays a Material `DropdownMenu` on long-press.
- `HoverableSlot` (commonMain) switches from `clickable` to `combinedClickable` so long-press works on nonJvm platforms.
- `MaterialEventCell` extracted into its own file with long-press + `DropdownMenu` (Edit / Copy / Delete).
- Strings `action_copy_event` / `action_paste_event` added in EN/FR/HE.

## Test plan
- [ ] `./gradlew :shared:jvmTest :shared:compileKotlinIosArm64 :desktopApp:assemble`
- [ ] `./gradlew :desktopApp:run`:
  - [ ] Right-click on an event → "Copy event"
  - [ ] Right-click on an empty slot → "Paste event" (hidden until something is copied)
  - [ ] Pasting preserves title/color/notes and the original duration
  - [ ] Pasting near the top of the window so the duration overflows → "out of window" snackbar
  - [ ] Pasting on an occupied slot → "overlap" snackbar
  - [ ] Pasting multiple times without copying again works
  - [ ] Pasting on another day works (DayOnly)