### PR TITLE
Add vertical scrollbars to event editor and settings dialogs

### DIFF
--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelEventEditor.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelEventEditor.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -45,6 +46,7 @@ import org.jetbrains.jewel.ui.component.OutlinedButton
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.TextArea
 import org.jetbrains.jewel.ui.component.TextField
+import org.jetbrains.jewel.ui.component.VerticalScrollbar
 import androidx.compose.foundation.shape.RoundedCornerShape
 import scheduleit.shared.generated.resources.Res
 import scheduleit.shared.generated.resources.action_cancel
@@ -80,7 +82,7 @@ fun JewelEventEditor(
 ) {
     val draft = editor.draft
     val bounds = computeEditorBounds(draft, siblings, editor.original, settings)
-    val state = rememberDialogState(size = DpSize(460.dp, 560.dp))
+    val state = rememberDialogState(size = DpSize(620.dp, 680.dp))
     val dialogTitle = stringResource(
         if (editor.mode == EventEditorState.Mode.Create) Res.string.event_dialog_new_title
         else Res.string.event_dialog_edit_title,
@@ -98,11 +100,13 @@ fun JewelEventEditor(
                 .padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
+            val scrollState = rememberScrollState()
+            Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
             Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-                    .verticalScroll(rememberScrollState()),
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+                    .padding(end = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(14.dp),
             ) {
                 if (editor.templateIsShared) {
@@ -182,6 +186,13 @@ fun JewelEventEditor(
                     editorKey = editor.draft.id to editor.mode,
                     onValueChange = { onIntent(ScheduleIntent.UpdateDraft(draft.copy(notes = it))) },
                 )
+            }
+            VerticalScrollbar(
+                scrollState = scrollState,
+                modifier = Modifier
+                    .align(androidx.compose.ui.Alignment.CenterEnd)
+                    .fillMaxHeight(),
+            )
             }
 
             Row(

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelSettingsWindow.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelSettingsWindow.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -44,6 +46,7 @@ import org.jetbrains.jewel.ui.component.Dropdown
 import org.jetbrains.jewel.ui.component.GroupHeader
 import org.jetbrains.jewel.ui.component.OutlinedButton
 import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.VerticalScrollbar
 import scheduleit.shared.generated.resources.Res
 import scheduleit.shared.generated.resources.action_cancel
 import scheduleit.shared.generated.resources.action_export
@@ -95,29 +98,41 @@ fun JewelSettingsWindow(
         title = title,
     ) {
         JewelDialogTitleBar { _ -> Text(title) }
-        Column(
+        Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .background(JewelTheme.globalColors.panelBackground)
-                .verticalScroll(rememberScrollState())
-                .padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp),
+                .fillMaxSize()
+                .background(JewelTheme.globalColors.panelBackground),
         ) {
-            HoursSection(
-                startHour = state.settings.startMinute / 60,
-                endHour = state.settings.endMinute / 60,
-                onIntent = onIntent,
+            val scrollState = rememberScrollState()
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+                    .padding(start = 20.dp, end = 32.dp, top = 20.dp, bottom = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+            ) {
+                HoursSection(
+                    startHour = state.settings.startMinute / 60,
+                    endHour = state.settings.endMinute / 60,
+                    onIntent = onIntent,
+                )
+
+                DaysSection(state = state, onIntent = onIntent)
+
+                // TODO: re-enable once notifications behave reliably across platforms.
+                // NotificationsSection(
+                //     enabled = state.settings.notificationsEnabled,
+                //     onIntent = onIntent,
+                // )
+
+                DataSection(onIntent = onIntent)
+            }
+            VerticalScrollbar(
+                scrollState = scrollState,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .fillMaxHeight(),
             )
-
-            DaysSection(state = state, onIntent = onIntent)
-
-            // TODO: re-enable once notifications behave reliably across platforms.
-            // NotificationsSection(
-            //     enabled = state.settings.notificationsEnabled,
-            //     onIntent = onIntent,
-            // )
-
-            DataSection(onIntent = onIntent)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a Jewel `VerticalScrollbar` to the event editor dialog, bound to the scrollable form column.
- Add a `VerticalScrollbar` to the settings dialog so longer device/setting lists scroll cleanly.
- Enlarge the event editor dialog from 460x560 to 620x680 to fit the form without wrapping.

## Test plan
- [ ] Open the event editor on desktop — confirm scrollbar appears and tracks the form.
- [ ] Open the settings dialog — confirm the scrollbar appears and content padding clears the track.
- [ ] Verify dialogs still resize / drag normally with the new sizing.