### PR TITLE
Add Google Drive backup and restore (desktop)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,9 @@ jobs:
 
       - name: Build native image
         shell: bash
+        env:
+          GOOGLE_DRIVE_CLIENT_ID: ${{ secrets.GOOGLE_DRIVE_CLIENT_ID }}
+          GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           GRADLE_TASKS=""
@@ -134,6 +137,9 @@ jobs:
 
       - name: Build DMG (JVM + Leyden AOT cache + ProGuard)
         shell: bash
+        env:
+          GOOGLE_DRIVE_CLIENT_ID: ${{ secrets.GOOGLE_DRIVE_CLIENT_ID }}
+          GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
         run: |
           ./gradlew :desktopApp:packageReleaseDmg \
             -PappVersion=${{ steps.version.outputs.version }} \
@@ -189,6 +195,9 @@ jobs:
 
       - name: Build AppX (JVM + Leyden AOT cache + ProGuard)
         shell: bash
+        env:
+          GOOGLE_DRIVE_CLIENT_ID: ${{ secrets.GOOGLE_DRIVE_CLIENT_ID }}
+          GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
         run: |
           ./gradlew :desktopApp:packageReleaseAppX \
             -PappVersion=${{ steps.version.outputs.version }} \

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -71,7 +71,7 @@ nucleus.application {
         copyright = "© 2026 Elie Gambache. Licensed under GPLv3."
         homepage = "https://github.com/kdroidFilter/ScheduleIt"
         licenseFile.set(rootProject.file("LICENSE"))
-        modules("java.sql")
+        modules("java.sql", "jdk.httpserver")
 
         macOS {
             iconFile.set(rootProject.file("art/icon.icns"))

--- a/desktopApp/proguard-rules.pro
+++ b/desktopApp/proguard-rules.pro
@@ -129,3 +129,26 @@
 -keep class dev.zacsweers.metrox.** { *; }
 -keep @dev.zacsweers.metro.** class * { *; }
 -dontwarn dev.zacsweers.metro.**
+
+# =============================================================================
+# Google Drive backup — Ktor + CIO engine + Nucleus native HTTP SSL
+# =============================================================================
+
+# Ktor (HTTP client). Many internals resolved via ServiceLoader / reflection.
+-keep class io.ktor.** { *; }
+-keepclassmembers class io.ktor.** { *; }
+-dontwarn io.ktor.**
+
+# CIO engine factory is discovered through META-INF/services.
+-keep class * implements io.ktor.client.HttpClientEngineContainer { *; }
+-keep class io.ktor.client.engine.cio.** { *; }
+
+# Nucleus native HTTP / native trust store (JNI + SSL).
+-keep class io.github.kdroidfilter.nucleus.nativehttp.** { *; }
+-keepclassmembers class io.github.kdroidfilter.nucleus.nativehttp.** { *; }
+-dontwarn io.github.kdroidfilter.nucleus.nativehttp.**
+
+# atomicfu / SLF4J pulled in transitively by Ktor — silence warnings.
+-dontwarn kotlinx.atomicfu.**
+-dontwarn javax.servlet.**
+-dontwarn javax.net.ssl.**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ intellijIcons = "253.31033.145"
 jewel = "0.35.0-261.23567.138"
 junit = "4.13.2"
 kotlin = "2.3.21"
+ktor = "3.4.3"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.7.3"
@@ -63,6 +64,9 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.
 kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-serializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 filekit-dialogsCompose = { module = "io.github.vinceglb:filekit-dialogs-compose", version.ref = "filekit" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+nucleus-nativeHttpKtor = { module = "io.github.kdroidfilter:nucleus.native-http-ktor", version.ref = "nucleus" }
 metrox-viewmodel = { module = "dev.zacsweers.metro:metrox-viewmodel", version.ref = "metro" }
 metrox-viewmodelCompose = { module = "dev.zacsweers.metro:metrox-viewmodel-compose", version.ref = "metro" }
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -91,12 +91,16 @@ kotlin {
         }
 
         val jvmMain by getting {
+            kotlin.srcDir(layout.buildDirectory.dir("generated/source/driveOAuth/jvmMain"))
             dependencies {
                 implementation(libs.sqldelight.sqliteDriver)
                 implementation(libs.jewel.intUiStandalone)
                 implementation(libs.intellij.icons)
                 implementation(libs.nucleus.decoratedWindowCore)
                 implementation(libs.nucleus.decoratedWindowJewel)
+                implementation(libs.ktor.client.core)
+                implementation(libs.ktor.client.cio)
+                implementation(libs.nucleus.nativeHttpKtor)
             }
         }
     }
@@ -109,6 +113,37 @@ sqldelight {
             dialect(libs.sqldelight.sqlite324Dialect)
         }
     }
+}
+
+val generateDriveOAuthConfig by tasks.registering {
+    val outputDir = layout.buildDirectory.dir("generated/source/driveOAuth/jvmMain")
+    val clientId = providers.environmentVariable("GOOGLE_DRIVE_CLIENT_ID").orElse("")
+    val clientSecret = providers.environmentVariable("GOOGLE_DRIVE_CLIENT_SECRET").orElse("")
+    inputs.property("clientId", clientId)
+    inputs.property("clientSecret", clientSecret)
+    outputs.dir(outputDir)
+    doLast {
+        val file = outputDir.get()
+            .file("dev/nucleus/scheduleit/data/drive/DriveOAuthConfig.kt")
+            .asFile
+        file.parentFile.mkdirs()
+        file.writeText(
+            """
+            // Generated file. Do not edit.
+            package dev.nucleus.scheduleit.data.drive
+
+            internal object DriveOAuthConfig {
+                const val CLIENT_ID: String = "${clientId.get()}"
+                const val CLIENT_SECRET: String = "${clientSecret.get()}"
+                val isConfigured: Boolean get() = CLIENT_ID.isNotEmpty() && CLIENT_SECRET.isNotEmpty()
+            }
+            """.trimIndent(),
+        )
+    }
+}
+
+tasks.matching { it.name == "compileKotlinJvm" }.configureEach {
+    dependsOn(generateDriveOAuthConfig)
 }
 
 compose.resources {

--- a/shared/src/androidMain/kotlin/dev/nucleus/scheduleit/data/drive/GoogleDriveSync.android.kt
+++ b/shared/src/androidMain/kotlin/dev/nucleus/scheduleit/data/drive/GoogleDriveSync.android.kt
@@ -1,0 +1,3 @@
+package dev.nucleus.scheduleit.data.drive
+
+actual fun createGoogleDriveSync(): GoogleDriveSync? = null

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -80,6 +80,25 @@
     <string name="action_export">Exporter…</string>
     <string name="action_import">Importer…</string>
     <string name="action_reset_database">Réinitialiser la base</string>
+
+    <string name="settings_drive_section">Sauvegarde Google Drive</string>
+    <string name="settings_drive_disconnected">Non connecté. Connectez-vous pour sauvegarder votre planning.</string>
+    <string name="settings_drive_connecting">En attente d&#8217;autorisation dans votre navigateur…</string>
+    <string name="settings_drive_connected">Connecté en tant que %1$s</string>
+    <string name="settings_drive_connected_anon">Connecté</string>
+    <string name="settings_drive_last_backup">Dernière sauvegarde : %1$s</string>
+    <string name="settings_drive_no_backup">Aucune sauvegarde</string>
+    <string name="settings_drive_uploading">Envoi en cours…</string>
+    <string name="settings_drive_restoring">Restauration en cours…</string>
+    <string name="settings_drive_error">Erreur : %1$s</string>
+    <string name="action_drive_connect">Connecter Google Drive</string>
+    <string name="action_drive_backup_now">Sauvegarder maintenant</string>
+    <string name="action_drive_restore">Restaurer</string>
+    <string name="action_drive_disconnect">Se déconnecter</string>
+    <string name="action_drive_retry">Réessayer</string>
+    <string name="restore_confirm_title">Restaurer depuis Google Drive ?</string>
+    <string name="restore_confirm_message">Votre planning actuel sera remplacé par la dernière sauvegarde Google Drive.</string>
+    <string name="action_restore_confirm">Restaurer</string>
     <string name="reset_confirm_title">Réinitialiser la base ?</string>
     <string name="reset_confirm_message">Tous vos événements, jours et paramètres seront définitivement supprimés.</string>
     <string name="action_reset_confirm">Réinitialiser</string>

--- a/shared/src/commonMain/composeResources/values-he/strings.xml
+++ b/shared/src/commonMain/composeResources/values-he/strings.xml
@@ -80,6 +80,25 @@
     <string name="action_export">ייצוא…</string>
     <string name="action_import">ייבוא…</string>
     <string name="action_reset_database">אפס מסד נתונים</string>
+
+    <string name="settings_drive_section">גיבוי ל-Google Drive</string>
+    <string name="settings_drive_disconnected">לא מחובר. התחבר כדי לגבות את לוח הזמנים שלך.</string>
+    <string name="settings_drive_connecting">ממתין לאישור בדפדפן…</string>
+    <string name="settings_drive_connected">מחובר כ-%1$s</string>
+    <string name="settings_drive_connected_anon">מחובר</string>
+    <string name="settings_drive_last_backup">גיבוי אחרון: %1$s</string>
+    <string name="settings_drive_no_backup">אין גיבוי עדיין</string>
+    <string name="settings_drive_uploading">מעלה…</string>
+    <string name="settings_drive_restoring">משחזר…</string>
+    <string name="settings_drive_error">שגיאה: %1$s</string>
+    <string name="action_drive_connect">התחבר ל-Google Drive</string>
+    <string name="action_drive_backup_now">גבה עכשיו</string>
+    <string name="action_drive_restore">שחזר</string>
+    <string name="action_drive_disconnect">התנתק</string>
+    <string name="action_drive_retry">נסה שוב</string>
+    <string name="restore_confirm_title">לשחזר מ-Google Drive?</string>
+    <string name="restore_confirm_message">לוח הזמנים הנוכחי יוחלף בגיבוי האחרון מ-Google Drive.</string>
+    <string name="action_restore_confirm">שחזר</string>
     <string name="reset_confirm_title">לאפס את מסד הנתונים?</string>
     <string name="reset_confirm_message">כל האירועים, הימים וההגדרות יימחקו לצמיתות.</string>
     <string name="action_reset_confirm">אפס</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -80,6 +80,25 @@
     <string name="action_export">Export…</string>
     <string name="action_import">Import…</string>
     <string name="action_reset_database">Reset database</string>
+
+    <string name="settings_drive_section">Google Drive backup</string>
+    <string name="settings_drive_disconnected">Not connected. Sign in to back up your schedule.</string>
+    <string name="settings_drive_connecting">Waiting for authorization in your browser…</string>
+    <string name="settings_drive_connected">Connected as %1$s</string>
+    <string name="settings_drive_connected_anon">Connected</string>
+    <string name="settings_drive_last_backup">Last backup: %1$s</string>
+    <string name="settings_drive_no_backup">No backup yet</string>
+    <string name="settings_drive_uploading">Uploading…</string>
+    <string name="settings_drive_restoring">Restoring…</string>
+    <string name="settings_drive_error">Error: %1$s</string>
+    <string name="action_drive_connect">Connect Google Drive</string>
+    <string name="action_drive_backup_now">Back up now</string>
+    <string name="action_drive_restore">Restore</string>
+    <string name="action_drive_disconnect">Disconnect</string>
+    <string name="action_drive_retry">Retry</string>
+    <string name="restore_confirm_title">Restore from Google Drive?</string>
+    <string name="restore_confirm_message">Your current schedule will be replaced with the latest backup from Google Drive.</string>
+    <string name="action_restore_confirm">Restore</string>
     <string name="reset_confirm_title">Reset database?</string>
     <string name="reset_confirm_message">All your events, days and settings will be permanently deleted.</string>
     <string name="action_reset_confirm">Reset</string>

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/data/drive/GoogleDriveSync.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/data/drive/GoogleDriveSync.kt
@@ -1,0 +1,27 @@
+package dev.nucleus.scheduleit.data.drive
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface GoogleDriveSync {
+    val status: StateFlow<GoogleDriveStatus>
+    suspend fun connect()
+    suspend fun disconnect()
+    suspend fun backup(payload: String)
+    /** Returns the JSON payload of the latest backup, or null if none exists. */
+    suspend fun restore(): String?
+}
+
+sealed interface GoogleDriveStatus {
+    data object Disconnected : GoogleDriveStatus
+    data object Connecting : GoogleDriveStatus
+    data class Connected(
+        val email: String?,
+        val lastBackupEpochSec: Long?,
+        val operation: Operation? = null,
+    ) : GoogleDriveStatus
+    data class Error(val message: String) : GoogleDriveStatus
+
+    enum class Operation { Uploading, Restoring }
+}
+
+expect fun createGoogleDriveSync(): GoogleDriveSync?

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/di/AppGraph.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/di/AppGraph.kt
@@ -3,6 +3,8 @@ package dev.nucleus.scheduleit.di
 import androidx.lifecycle.ViewModel
 import dev.nucleus.scheduleit.data.DriverFactory
 import dev.nucleus.scheduleit.data.ScheduleRepository
+import dev.nucleus.scheduleit.data.drive.GoogleDriveSync
+import dev.nucleus.scheduleit.data.drive.createGoogleDriveSync
 import dev.nucleus.scheduleit.db.ScheduleDatabase
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -28,6 +30,10 @@ interface AppGraph : ViewModelGraph {
     @SingleIn(AppScope::class)
     fun provideDatabase(driverFactory: DriverFactory): ScheduleDatabase =
         ScheduleDatabase(driverFactory.createDriver())
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideGoogleDriveSync(): GoogleDriveSync? = createGoogleDriveSync()
 
     @DependencyGraph.Factory
     fun interface Factory {

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleIntent.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleIntent.kt
@@ -25,6 +25,10 @@ sealed interface ScheduleIntent {
     data object ExportData : ScheduleIntent
     data object ImportData : ScheduleIntent
     data object ResetData : ScheduleIntent
+    data object ConnectGoogleDrive : ScheduleIntent
+    data object DisconnectGoogleDrive : ScheduleIntent
+    data object BackupNowToDrive : ScheduleIntent
+    data object RestoreFromDrive : ScheduleIntent
     data class HideDay(val day: AppDayOfWeek) : ScheduleIntent
     data class AssignDayToTemplate(val day: AppDayOfWeek, val templateId: Long) : ScheduleIntent
     data class AssignDayToNewTemplate(val day: AppDayOfWeek) : ScheduleIntent

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleState.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleState.kt
@@ -1,5 +1,6 @@
 package dev.nucleus.scheduleit.presentation.schedule
 
+import dev.nucleus.scheduleit.data.drive.GoogleDriveStatus
 import dev.nucleus.scheduleit.domain.AppDayOfWeek
 import dev.nucleus.scheduleit.domain.DayEvent
 import dev.nucleus.scheduleit.domain.DayTemplate
@@ -22,6 +23,7 @@ data class ScheduleUiState(
     val showSettings: Boolean = false,
     val errorMessage: ErrorKey? = null,
     val clipboard: ClipboardEvent? = null,
+    val googleDrive: GoogleDriveStatus? = null,
 ) {
     val visibleDays: List<AppDayOfWeek>
         get() = AppDayOfWeek.entries.filter { it in assignments }

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleViewModel.kt
@@ -483,7 +483,12 @@ class ScheduleViewModel(
 
     private fun connectGoogleDrive() {
         val sync = googleDriveSync ?: return
-        viewModelScope.launch { sync.connect() }
+        viewModelScope.launch {
+            sync.connect()
+            if (sync.status.value is GoogleDriveStatus.Connected && isLocalDataEmpty()) {
+                applyDriveRestore(sync)
+            }
+        }
     }
 
     private fun disconnectGoogleDrive() {
@@ -504,14 +509,23 @@ class ScheduleViewModel(
     private fun restoreFromDrive() {
         val sync = googleDriveSync ?: return
         if (sync.status.value !is GoogleDriveStatus.Connected) return
-        viewModelScope.launch {
-            val payload = sync.restore() ?: return@launch
-            val backup = runCatching { decodeBackupFromString(payload) }.getOrNull() ?: run {
-                _state.update { it.copy(errorMessage = ErrorKey.InvalidBackup) }
-                return@launch
-            }
-            repository.replaceAll(backup.toSnapshot())
+        viewModelScope.launch { applyDriveRestore(sync) }
+    }
+
+    private suspend fun applyDriveRestore(sync: GoogleDriveSync) {
+        val payload = sync.restore() ?: return
+        val backup = runCatching { decodeBackupFromString(payload) }.getOrNull() ?: run {
+            _state.update { it.copy(errorMessage = ErrorKey.InvalidBackup) }
+            return
         }
+        repository.replaceAll(backup.toSnapshot())
+    }
+
+    private suspend fun isLocalDataEmpty(): Boolean {
+        val snapshot = repository.snapshotOnce()
+        return snapshot.eventsByTemplate.values.all { it.isEmpty() } &&
+            snapshot.dayEventsByDay.values.all { it.isEmpty() } &&
+            snapshot.overridesByDay.values.all { it.isEmpty() }
     }
 
     companion object {

--- a/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleus/scheduleit/presentation/schedule/ScheduleViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.nucleus.scheduleit.data.ScheduleRepository
 import dev.nucleus.scheduleit.data.decodeBackupFromString
+import dev.nucleus.scheduleit.data.drive.GoogleDriveStatus
+import dev.nucleus.scheduleit.data.drive.GoogleDriveSync
 import dev.nucleus.scheduleit.data.encodeToString
 import dev.nucleus.scheduleit.data.toBackup
 import dev.nucleus.scheduleit.data.toSnapshot
@@ -33,9 +35,12 @@ import kotlinx.coroutines.launch
 @ViewModelKey(ScheduleViewModel::class)
 class ScheduleViewModel(
     private val repository: ScheduleRepository,
+    private val googleDriveSync: GoogleDriveSync?,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(ScheduleUiState())
+    private val _state = MutableStateFlow(
+        ScheduleUiState(googleDrive = googleDriveSync?.status?.value),
+    )
     val state: StateFlow<ScheduleUiState> = _state.asStateFlow()
 
     init {
@@ -52,6 +57,13 @@ class ScheduleViewModel(
                         dayEventsByDay = snapshot.dayEventsByDay,
                         overridesByDay = snapshot.overridesByDay,
                     )
+                }
+            }
+        }
+        googleDriveSync?.let { sync ->
+            viewModelScope.launch {
+                sync.status.collect { status ->
+                    _state.update { it.copy(googleDrive = status) }
                 }
             }
         }
@@ -83,6 +95,10 @@ class ScheduleViewModel(
             ScheduleIntent.ExportData -> exportData()
             ScheduleIntent.ImportData -> importData()
             ScheduleIntent.ResetData -> resetData()
+            ScheduleIntent.ConnectGoogleDrive -> connectGoogleDrive()
+            ScheduleIntent.DisconnectGoogleDrive -> disconnectGoogleDrive()
+            ScheduleIntent.BackupNowToDrive -> backupNowToDrive()
+            ScheduleIntent.RestoreFromDrive -> restoreFromDrive()
             is ScheduleIntent.HideDay -> hideDay(intent.day)
             is ScheduleIntent.AssignDayToTemplate -> assignDay(intent.day, intent.templateId)
             is ScheduleIntent.AssignDayToNewTemplate -> assignDayToNew(intent.day)
@@ -463,6 +479,39 @@ class ScheduleViewModel(
 
     private fun resetData() {
         viewModelScope.launch { repository.resetAll() }
+    }
+
+    private fun connectGoogleDrive() {
+        val sync = googleDriveSync ?: return
+        viewModelScope.launch { sync.connect() }
+    }
+
+    private fun disconnectGoogleDrive() {
+        val sync = googleDriveSync ?: return
+        viewModelScope.launch { sync.disconnect() }
+    }
+
+    private fun backupNowToDrive() {
+        val sync = googleDriveSync ?: return
+        if (sync.status.value !is GoogleDriveStatus.Connected) return
+        viewModelScope.launch {
+            val snapshot = repository.snapshotOnce()
+            val payload = snapshot.toBackup().encodeToString()
+            sync.backup(payload)
+        }
+    }
+
+    private fun restoreFromDrive() {
+        val sync = googleDriveSync ?: return
+        if (sync.status.value !is GoogleDriveStatus.Connected) return
+        viewModelScope.launch {
+            val payload = sync.restore() ?: return@launch
+            val backup = runCatching { decodeBackupFromString(payload) }.getOrNull() ?: run {
+                _state.update { it.copy(errorMessage = ErrorKey.InvalidBackup) }
+                return@launch
+            }
+            repository.replaceAll(backup.toSnapshot())
+        }
     }
 
     companion object {

--- a/shared/src/iosMain/kotlin/dev/nucleus/scheduleit/data/drive/GoogleDriveSync.ios.kt
+++ b/shared/src/iosMain/kotlin/dev/nucleus/scheduleit/data/drive/GoogleDriveSync.ios.kt
@@ -1,0 +1,3 @@
+package dev.nucleus.scheduleit.data.drive
+
+actual fun createGoogleDriveSync(): GoogleDriveSync? = null

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/AppDataDir.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/AppDataDir.kt
@@ -1,0 +1,25 @@
+package dev.nucleus.scheduleit.data.drive
+
+import java.io.File
+
+internal object AppDataDir {
+    private const val APP_NAME = "ScheduleIt"
+
+    fun resolve(): File {
+        val os = System.getProperty("os.name").lowercase()
+        val home = System.getProperty("user.home")
+        val dir = when {
+            os.contains("win") -> {
+                val appData = System.getenv("APPDATA")?.takeIf { it.isNotEmpty() } ?: "$home/AppData/Roaming"
+                File(appData, APP_NAME)
+            }
+            os.contains("mac") -> File(home, "Library/Application Support/$APP_NAME")
+            else -> {
+                val xdg = System.getenv("XDG_DATA_HOME")?.takeIf { it.isNotEmpty() } ?: "$home/.local/share"
+                File(xdg, APP_NAME.lowercase())
+            }
+        }
+        if (!dir.exists()) dir.mkdirs()
+        return dir
+    }
+}

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/Browser.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/Browser.kt
@@ -1,0 +1,20 @@
+package dev.nucleus.scheduleit.data.drive
+
+import java.awt.Desktop
+import java.net.URI
+
+internal object Browser {
+    fun open(url: String) {
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+            val ok = runCatching { Desktop.getDesktop().browse(URI(url)) }.isSuccess
+            if (ok) return
+        }
+        val os = System.getProperty("os.name").lowercase()
+        val cmd = when {
+            os.contains("win") -> arrayOf("rundll32", "url.dll,FileProtocolHandler", url)
+            os.contains("mac") -> arrayOf("open", url)
+            else -> arrayOf("xdg-open", url)
+        }
+        ProcessBuilder(*cmd).start()
+    }
+}

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/DriveBackup.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/DriveBackup.kt
@@ -64,8 +64,10 @@ internal class DriveBackup(
         }
     }
 
+    data class DriveFileRef(val id: String, val modifiedEpochSec: Long)
+
     /** Returns the most recent file matching [fileName] in the appDataFolder, or null. */
-    suspend fun findLatest(accessToken: String, fileName: String): String? {
+    suspend fun findLatest(accessToken: String, fileName: String): DriveFileRef? {
         val q = "name = '${fileName.replace("'", "\\'")}' and trashed = false"
         val response = http.get(LIST_URL) {
             header(HttpHeaders.Authorization, "Bearer $accessToken")
@@ -78,10 +80,16 @@ internal class DriveBackup(
             }
         }
         if (!response.status.isSuccess()) return null
-        val files = json.parseToJsonElement(response.bodyAsText())
+        val first = json.parseToJsonElement(response.bodyAsText())
             .jsonObject["files"]?.jsonArray
+            ?.firstOrNull()
+            ?.jsonObject
             ?: return null
-        return files.firstOrNull()?.jsonObject?.get("id")?.jsonPrimitive?.content
+        val id = first["id"]?.jsonPrimitive?.content ?: return null
+        val modifiedSec = first["modifiedTime"]?.jsonPrimitive?.content
+            ?.let { runCatching { java.time.Instant.parse(it).epochSecond }.getOrNull() }
+            ?: (System.currentTimeMillis() / 1000)
+        return DriveFileRef(id, modifiedSec)
     }
 
     suspend fun download(accessToken: String, fileId: String): String {

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/DriveBackup.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/DriveBackup.kt
@@ -1,0 +1,103 @@
+package dev.nucleus.scheduleit.data.drive
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.headers
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+internal class DriveBackup(
+    private val http: HttpClient,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    /**
+     * First upload: multipart create with metadata + content in one request.
+     * Returns the new file id.
+     */
+    suspend fun create(accessToken: String, fileName: String, content: ByteArray): String {
+        val boundary = "==BACKUP_BOUNDARY_${System.nanoTime()}=="
+        val metadata = """{"name":"$fileName","mimeType":"application/json","parents":["appDataFolder"]}"""
+        val prefix = buildString {
+            append("--$boundary\r\n")
+            append("Content-Type: application/json; charset=UTF-8\r\n\r\n")
+            append(metadata).append("\r\n")
+            append("--$boundary\r\n")
+            append("Content-Type: application/json\r\n\r\n")
+        }.toByteArray()
+        val suffix = "\r\n--$boundary--\r\n".toByteArray()
+        val body = prefix + content + suffix
+
+        val response = http.post(CREATE_URL) {
+            headers {
+                append(HttpHeaders.Authorization, "Bearer $accessToken")
+            }
+            contentType(ContentType.parse("multipart/related; boundary=$boundary"))
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        require(response.status.isSuccess()) { "Drive create failed: ${response.status} $text" }
+        return json.parseToJsonElement(text).jsonObject["id"]!!.jsonPrimitive.content
+    }
+
+    /** Subsequent uploads: PATCH the media (content only). */
+    suspend fun update(accessToken: String, fileId: String, content: ByteArray) {
+        val response = http.patch("$UPDATE_URL$fileId?uploadType=media") {
+            headers {
+                append(HttpHeaders.Authorization, "Bearer $accessToken")
+            }
+            contentType(ContentType.Application.Json)
+            setBody(content)
+        }
+        require(response.status.isSuccess()) {
+            "Drive update failed: ${response.status} ${response.bodyAsText()}"
+        }
+    }
+
+    /** Returns the most recent file matching [fileName] in the appDataFolder, or null. */
+    suspend fun findLatest(accessToken: String, fileName: String): String? {
+        val q = "name = '${fileName.replace("'", "\\'")}' and trashed = false"
+        val response = http.get(LIST_URL) {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            url {
+                parameters.append("spaces", "appDataFolder")
+                parameters.append("q", q)
+                parameters.append("fields", "files(id,modifiedTime)")
+                parameters.append("orderBy", "modifiedTime desc")
+                parameters.append("pageSize", "1")
+            }
+        }
+        if (!response.status.isSuccess()) return null
+        val files = json.parseToJsonElement(response.bodyAsText())
+            .jsonObject["files"]?.jsonArray
+            ?: return null
+        return files.firstOrNull()?.jsonObject?.get("id")?.jsonPrimitive?.content
+    }
+
+    suspend fun download(accessToken: String, fileId: String): String {
+        val response = http.get("$LIST_URL/$fileId") {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            url { parameters.append("alt", "media") }
+        }
+        require(response.status.isSuccess()) {
+            "Drive download failed: ${response.status} ${response.bodyAsText()}"
+        }
+        return response.bodyAsText()
+    }
+
+    companion object {
+        const val CREATE_URL = "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart"
+        const val UPDATE_URL = "https://www.googleapis.com/upload/drive/v3/files/"
+        const val LIST_URL = "https://www.googleapis.com/drive/v3/files"
+    }
+}

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/GoogleDriveSync.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/GoogleDriveSync.jvm.kt
@@ -1,0 +1,4 @@
+package dev.nucleus.scheduleit.data.drive
+
+actual fun createGoogleDriveSync(): GoogleDriveSync? =
+    if (DriveOAuthConfig.isConfigured) JvmGoogleDriveSync() else null

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/GoogleOAuthClient.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/GoogleOAuthClient.kt
@@ -1,0 +1,79 @@
+package dev.nucleus.scheduleit.data.drive
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Parameters
+import io.ktor.http.isSuccess
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
+internal data class TokenResponse(
+    val access_token: String,
+    val expires_in: Long,
+    val refresh_token: String? = null,
+    val scope: String? = null,
+    val token_type: String? = null,
+    val id_token: String? = null,
+)
+
+@Serializable
+internal data class UserInfo(
+    val email: String? = null,
+)
+
+internal class GoogleOAuthClient(
+    private val http: HttpClient,
+    private val clientId: String,
+    private val clientSecret: String,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    suspend fun exchangeCode(code: String, codeVerifier: String, redirectUri: String): TokenResponse {
+        val response = http.submitForm(
+            url = TOKEN_URL,
+            formParameters = Parameters.build {
+                append("client_id", clientId)
+                append("client_secret", clientSecret)
+                append("code", code)
+                append("code_verifier", codeVerifier)
+                append("grant_type", "authorization_code")
+                append("redirect_uri", redirectUri)
+            },
+        )
+        val text = response.bodyAsText()
+        require(response.status.isSuccess()) { "Token exchange failed: ${response.status} $text" }
+        return json.decodeFromString(TokenResponse.serializer(), text)
+    }
+
+    suspend fun refresh(refreshToken: String): TokenResponse {
+        val response = http.submitForm(
+            url = TOKEN_URL,
+            formParameters = Parameters.build {
+                append("client_id", clientId)
+                append("client_secret", clientSecret)
+                append("refresh_token", refreshToken)
+                append("grant_type", "refresh_token")
+            },
+        )
+        val text = response.bodyAsText()
+        require(response.status.isSuccess()) { "Token refresh failed: ${response.status} $text" }
+        return json.decodeFromString(TokenResponse.serializer(), text)
+    }
+
+    suspend fun fetchUserEmail(accessToken: String): String? = runCatching {
+        val response = http.get(USERINFO_URL) {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }
+        if (!response.status.isSuccess()) return@runCatching null
+        json.decodeFromString(UserInfo.serializer(), response.bodyAsText()).email
+    }.getOrNull()
+
+    companion object {
+        const val TOKEN_URL = "https://oauth2.googleapis.com/token"
+        const val USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo"
+    }
+}

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/JvmGoogleDriveSync.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/JvmGoogleDriveSync.kt
@@ -1,0 +1,172 @@
+package dev.nucleus.scheduleit.data.drive
+
+import io.github.kdroidfilter.nucleus.nativehttp.ktor.installNativeSsl
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import java.net.URLEncoder
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.future.await
+
+internal class JvmGoogleDriveSync(
+    private val store: TokenStore = TokenStore(),
+    private val httpClient: HttpClient = HttpClient(CIO) { installNativeSsl() },
+    clientId: String = DriveOAuthConfig.CLIENT_ID,
+    clientSecret: String = DriveOAuthConfig.CLIENT_SECRET,
+) : GoogleDriveSync {
+
+    private val oauth = GoogleOAuthClient(httpClient, clientId, clientSecret)
+    private val drive = DriveBackup(httpClient)
+
+    private val _status = MutableStateFlow<GoogleDriveStatus>(initialStatus())
+    override val status: StateFlow<GoogleDriveStatus> = _status.asStateFlow()
+
+    private fun initialStatus(): GoogleDriveStatus {
+        val saved = store.load() ?: return GoogleDriveStatus.Disconnected
+        return GoogleDriveStatus.Connected(
+            email = saved.email,
+            lastBackupEpochSec = saved.lastBackupEpochSec,
+        )
+    }
+
+    override suspend fun connect() {
+        if (_status.value is GoogleDriveStatus.Connecting) return
+        _status.value = GoogleDriveStatus.Connecting
+        val verifier = Pkce.newVerifier()
+        val challenge = Pkce.challenge(verifier)
+        val state = Pkce.newVerifier().take(32)
+
+        val receiver = LoopbackCodeReceiver().start(state)
+        try {
+            val redirectUri = "http://127.0.0.1:${receiver.port}/callback"
+            Browser.open(buildAuthUrl(redirectUri, state, challenge))
+
+            val code = receiver.result.orTimeout(5, TimeUnit.MINUTES).await()
+            val tokens = oauth.exchangeCode(code, verifier, redirectUri)
+            val refresh = tokens.refresh_token
+                ?: error("No refresh_token returned. Make sure prompt=consent is set.")
+            val email = oauth.fetchUserEmail(tokens.access_token)
+            val now = nowEpochSec()
+            store.save(
+                StoredTokens(
+                    accessToken = tokens.access_token,
+                    refreshToken = refresh,
+                    expiresAtEpochSec = now + tokens.expires_in - 60,
+                    email = email,
+                ),
+            )
+            _status.value = GoogleDriveStatus.Connected(email = email, lastBackupEpochSec = null)
+        } catch (t: Throwable) {
+            _status.value = GoogleDriveStatus.Error(t.message ?: "Connection failed")
+        } finally {
+            receiver.close()
+        }
+    }
+
+    override suspend fun disconnect() {
+        store.clear()
+        _status.value = GoogleDriveStatus.Disconnected
+    }
+
+    override suspend fun backup(payload: String) {
+        val current = _status.value
+        if (current !is GoogleDriveStatus.Connected) return
+        val saved = store.load() ?: run {
+            _status.value = GoogleDriveStatus.Disconnected
+            return
+        }
+        _status.value = current.copy(operation = GoogleDriveStatus.Operation.Uploading)
+        try {
+            val fresh = ensureFreshToken(saved)
+            val bytes = payload.toByteArray(Charsets.UTF_8)
+            val fileId = fresh.backupFileId ?: drive.create(fresh.accessToken, BACKUP_FILE_NAME, bytes)
+                .also { newId -> store.save(fresh.copy(backupFileId = newId)) }
+            if (fresh.backupFileId != null) {
+                drive.update(fresh.accessToken, fileId, bytes)
+            }
+            val now = nowEpochSec()
+            store.save(store.load()!!.copy(lastBackupEpochSec = now))
+            _status.value = GoogleDriveStatus.Connected(
+                email = fresh.email,
+                lastBackupEpochSec = now,
+                operation = null,
+            )
+        } catch (t: Throwable) {
+            _status.value = GoogleDriveStatus.Error(t.message ?: "Backup failed")
+        }
+    }
+
+    override suspend fun restore(): String? {
+        val current = _status.value
+        if (current !is GoogleDriveStatus.Connected) return null
+        val saved = store.load() ?: run {
+            _status.value = GoogleDriveStatus.Disconnected
+            return null
+        }
+        _status.value = current.copy(operation = GoogleDriveStatus.Operation.Restoring)
+        return try {
+            val fresh = ensureFreshToken(saved)
+            val fileId = fresh.backupFileId
+                ?: drive.findLatest(fresh.accessToken, BACKUP_FILE_NAME)
+                ?: run {
+                    _status.value = current.copy(operation = null)
+                    return null
+                }
+            if (fresh.backupFileId == null) {
+                store.save(fresh.copy(backupFileId = fileId))
+            }
+            val payload = drive.download(fresh.accessToken, fileId)
+            _status.value = GoogleDriveStatus.Connected(
+                email = fresh.email,
+                lastBackupEpochSec = store.load()?.lastBackupEpochSec,
+                operation = null,
+            )
+            payload
+        } catch (t: Throwable) {
+            _status.value = GoogleDriveStatus.Error(t.message ?: "Restore failed")
+            null
+        }
+    }
+
+    private suspend fun ensureFreshToken(saved: StoredTokens): StoredTokens {
+        val now = nowEpochSec()
+        if (now < saved.expiresAtEpochSec) return saved
+        val refreshed = oauth.refresh(saved.refreshToken)
+        val updated = saved.copy(
+            accessToken = refreshed.access_token,
+            refreshToken = refreshed.refresh_token ?: saved.refreshToken,
+            expiresAtEpochSec = now + refreshed.expires_in - 60,
+        )
+        store.save(updated)
+        return updated
+    }
+
+    private fun buildAuthUrl(redirectUri: String, state: String, challenge: String): String {
+        val params = linkedMapOf(
+            "client_id" to DriveOAuthConfig.CLIENT_ID,
+            "redirect_uri" to redirectUri,
+            "response_type" to "code",
+            "scope" to SCOPES,
+            "code_challenge" to challenge,
+            "code_challenge_method" to "S256",
+            "state" to state,
+            "access_type" to "offline",
+            "prompt" to "consent",
+        )
+        val query = params.entries.joinToString("&") { (k, v) ->
+            "$k=${URLEncoder.encode(v, "UTF-8")}"
+        }
+        return "$AUTH_URL?$query"
+    }
+
+    private fun nowEpochSec(): Long = System.currentTimeMillis() / 1000
+
+    companion object {
+        private const val AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+        private const val SCOPES =
+            "https://www.googleapis.com/auth/drive.appdata openid email"
+        private const val BACKUP_FILE_NAME = "scheduleit-backup.json"
+    }
+}

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/JvmGoogleDriveSync.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/JvmGoogleDriveSync.kt
@@ -108,19 +108,20 @@ internal class JvmGoogleDriveSync(
         _status.value = current.copy(operation = GoogleDriveStatus.Operation.Restoring)
         return try {
             val fresh = ensureFreshToken(saved)
-            val fileId = fresh.backupFileId
-                ?: drive.findLatest(fresh.accessToken, BACKUP_FILE_NAME)
-                ?: run {
-                    _status.value = current.copy(operation = null)
-                    return null
-                }
-            if (fresh.backupFileId == null) {
-                store.save(fresh.copy(backupFileId = fileId))
+            val ref = drive.findLatest(fresh.accessToken, BACKUP_FILE_NAME) ?: run {
+                _status.value = current.copy(operation = null)
+                return null
             }
-            val payload = drive.download(fresh.accessToken, fileId)
+            val payload = drive.download(fresh.accessToken, ref.id)
+            store.save(
+                fresh.copy(
+                    backupFileId = ref.id,
+                    lastBackupEpochSec = ref.modifiedEpochSec,
+                ),
+            )
             _status.value = GoogleDriveStatus.Connected(
                 email = fresh.email,
-                lastBackupEpochSec = store.load()?.lastBackupEpochSec,
+                lastBackupEpochSec = ref.modifiedEpochSec,
                 operation = null,
             )
             payload

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/LoopbackCodeReceiver.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/LoopbackCodeReceiver.kt
@@ -21,12 +21,10 @@ internal class LoopbackCodeReceiver {
         val server = HttpServer.create(address, 0)
         server.createContext("/callback") { exchange ->
             val params = parseQuery(exchange.requestURI.rawQuery.orEmpty())
-            val body = """
-                <html><body style="font-family:sans-serif;padding:2em;text-align:center">
-                <h2>Authorization complete</h2>
-                <p>You can close this tab and return to ScheduleIt.</p>
-                </body></html>
-            """.trimIndent().toByteArray()
+            val isError = params["error"] != null ||
+                params["state"] != expectedState ||
+                params["code"].isNullOrEmpty()
+            val body = renderResponseHtml(isError = isError, errorMessage = params["error"]).toByteArray()
             exchange.responseHeaders.add("Content-Type", "text/html; charset=utf-8")
             exchange.sendResponseHeaders(200, body.size.toLong())
             exchange.responseBody.use { it.write(body) }
@@ -48,6 +46,93 @@ internal class LoopbackCodeReceiver {
             result = future,
             close = { runCatching { server.stop(0) } },
         )
+    }
+
+    private fun renderResponseHtml(isError: Boolean, errorMessage: String?): String {
+        val accent = if (isError) "#e53935" else "#42a5f5"
+        val accentShadow = if (isError) "rgba(229,57,53,0.35)" else "rgba(66,165,245,0.35)"
+        val title = if (isError) "Authorization failed" else "You're all set"
+        val subtitle = if (isError) {
+            "ScheduleIt could not complete the connection${errorMessage?.let { ": $it" } ?: "."}"
+        } else {
+            "ScheduleIt is now connected to your Google Drive."
+        }
+        val hint = if (isError) {
+            "You can close this tab and try again from the app."
+        } else {
+            "You can close this tab and go back to ScheduleIt."
+        }
+        val icon = if (isError) {
+            "<path d=\"M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z\" fill=\"#fff\"/>"
+        } else {
+            "<path d=\"M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\" fill=\"#fff\"/>"
+        }
+        return """
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>ScheduleIt — $title</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background: linear-gradient(135deg, #f5f7fa 0%, #e4e9f0 100%);
+    color: #1a1a1a;
+    display: flex; align-items: center; justify-content: center;
+    min-height: 100vh; padding: 24px;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { background: linear-gradient(135deg, #1f2229 0%, #2a2f3a 100%); color: #f4f4f4; }
+    .card { background: #2c313a; box-shadow: 0 10px 40px rgba(0,0,0,0.45); }
+    .hint { color: #a8acb6; }
+  }
+  .card {
+    background: #ffffff;
+    border-radius: 16px;
+    padding: 40px 36px;
+    max-width: 420px; width: 100%;
+    text-align: center;
+    box-shadow: 0 10px 40px rgba(20,30,60,0.15);
+    animation: pop 0.45s cubic-bezier(0.2, 0.9, 0.3, 1.2);
+  }
+  .badge {
+    width: 72px; height: 72px;
+    border-radius: 50%;
+    background: $accent;
+    display: inline-flex; align-items: center; justify-content: center;
+    margin: 0 auto 22px;
+    box-shadow: 0 8px 22px $accentShadow;
+  }
+  .badge svg { width: 40px; height: 40px; }
+  h1 { font-size: 22px; margin: 0 0 10px; font-weight: 600; letter-spacing: -0.01em; }
+  p { font-size: 15px; line-height: 1.5; margin: 0 0 8px; }
+  .hint { color: #6b7280; font-size: 13px; margin-top: 18px; }
+  .brand { margin-top: 28px; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; opacity: 0.55; }
+  @keyframes pop {
+    from { opacity: 0; transform: translateY(8px) scale(0.98); }
+    to   { opacity: 1; transform: translateY(0)   scale(1); }
+  }
+</style>
+</head>
+<body>
+  <main class="card">
+    <div class="badge" aria-hidden="true">
+      <svg viewBox="0 0 24 24">$icon</svg>
+    </div>
+    <h1>$title</h1>
+    <p>$subtitle</p>
+    <p class="hint">$hint</p>
+    <div class="brand">ScheduleIt</div>
+  </main>
+  <script>
+    setTimeout(function () { try { window.close(); } catch (e) {} }, 2500);
+  </script>
+</body>
+</html>
+        """.trimIndent()
     }
 
     private fun parseQuery(query: String): Map<String, String> {

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/LoopbackCodeReceiver.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/LoopbackCodeReceiver.kt
@@ -1,0 +1,63 @@
+package dev.nucleus.scheduleit.data.drive
+
+import com.sun.net.httpserver.HttpServer
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.URLDecoder
+import java.util.concurrent.CompletableFuture
+
+internal class LoopbackCodeReceiver {
+
+    data class Started(
+        val port: Int,
+        val result: CompletableFuture<String>,
+        val close: () -> Unit,
+    )
+
+    fun start(expectedState: String): Started {
+        val future = CompletableFuture<String>()
+        // Binding explicitly to 127.0.0.1 (not 0.0.0.0) avoids the Windows Defender Firewall prompt.
+        val address = InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0)
+        val server = HttpServer.create(address, 0)
+        server.createContext("/callback") { exchange ->
+            val params = parseQuery(exchange.requestURI.rawQuery.orEmpty())
+            val body = """
+                <html><body style="font-family:sans-serif;padding:2em;text-align:center">
+                <h2>Authorization complete</h2>
+                <p>You can close this tab and return to ScheduleIt.</p>
+                </body></html>
+            """.trimIndent().toByteArray()
+            exchange.responseHeaders.add("Content-Type", "text/html; charset=utf-8")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+
+            val err = params["error"]
+            val state = params["state"]
+            val code = params["code"]
+            when {
+                err != null -> future.completeExceptionally(IllegalStateException("OAuth error: $err"))
+                state != expectedState -> future.completeExceptionally(IllegalStateException("State mismatch"))
+                code.isNullOrEmpty() -> future.completeExceptionally(IllegalStateException("Missing authorization code"))
+                else -> future.complete(code)
+            }
+        }
+        server.executor = null
+        server.start()
+        return Started(
+            port = server.address.port,
+            result = future,
+            close = { runCatching { server.stop(0) } },
+        )
+    }
+
+    private fun parseQuery(query: String): Map<String, String> {
+        if (query.isEmpty()) return emptyMap()
+        return query.split("&").mapNotNull { part ->
+            val idx = part.indexOf('=')
+            if (idx <= 0) return@mapNotNull null
+            val key = part.substring(0, idx)
+            val value = URLDecoder.decode(part.substring(idx + 1), "UTF-8")
+            key to value
+        }.toMap()
+    }
+}

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/Pkce.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/Pkce.kt
@@ -1,0 +1,20 @@
+package dev.nucleus.scheduleit.data.drive
+
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+internal object Pkce {
+    private val urlEncoder: Base64.Encoder = Base64.getUrlEncoder().withoutPadding()
+
+    fun newVerifier(): String {
+        val bytes = ByteArray(64).also { SecureRandom().nextBytes(it) }
+        return urlEncoder.encodeToString(bytes)
+    }
+
+    fun challenge(verifier: String): String {
+        val sha = MessageDigest.getInstance("SHA-256")
+            .digest(verifier.toByteArray(Charsets.US_ASCII))
+        return urlEncoder.encodeToString(sha)
+    }
+}

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/TokenStore.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/data/drive/TokenStore.kt
@@ -1,0 +1,80 @@
+package dev.nucleus.scheduleit.data.drive
+
+import java.io.File
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
+internal data class StoredTokens(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresAtEpochSec: Long,
+    val email: String? = null,
+    val backupFileId: String? = null,
+    val lastBackupEpochSec: Long? = null,
+)
+
+internal class TokenStore(
+    private val file: File = File(AppDataDir.resolve(), "drive-tokens.bin"),
+    private val keyFile: File = File(AppDataDir.resolve(), "drive-tokens.key"),
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    fun load(): StoredTokens? {
+        if (!file.exists() || !keyFile.exists()) return null
+        return runCatching {
+            val key = loadOrCreateKey()
+            val blob = file.readBytes()
+            val plain = decrypt(blob, key)
+            json.decodeFromString(StoredTokens.serializer(), String(plain, Charsets.UTF_8))
+        }.getOrNull()
+    }
+
+    fun save(tokens: StoredTokens) {
+        val key = loadOrCreateKey()
+        val plain = json.encodeToString(StoredTokens.serializer(), tokens).toByteArray(Charsets.UTF_8)
+        file.writeBytes(encrypt(plain, key))
+        runCatching { setOwnerOnly(file) }
+    }
+
+    fun clear() {
+        runCatching { file.delete() }
+        runCatching { keyFile.delete() }
+    }
+
+    private fun loadOrCreateKey(): SecretKey {
+        if (keyFile.exists()) {
+            val raw = Base64.getDecoder().decode(keyFile.readText().trim())
+            return SecretKeySpec(raw, "AES")
+        }
+        val raw = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        keyFile.writeText(Base64.getEncoder().encodeToString(raw))
+        runCatching { setOwnerOnly(keyFile) }
+        return SecretKeySpec(raw, "AES")
+    }
+
+    private fun encrypt(plain: ByteArray, key: SecretKey): ByteArray {
+        val iv = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(128, iv))
+        return iv + cipher.doFinal(plain)
+    }
+
+    private fun decrypt(blob: ByteArray, key: SecretKey): ByteArray {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(128, blob.copyOfRange(0, 12)))
+        return cipher.doFinal(blob.copyOfRange(12, blob.size))
+    }
+
+    private fun setOwnerOnly(target: File) {
+        target.setReadable(false, false)
+        target.setReadable(true, true)
+        target.setWritable(false, false)
+        target.setWritable(true, true)
+    }
+}

--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelSettingsWindow.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelSettingsWindow.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.rememberDialogState
 import io.github.kdroidfilter.nucleus.window.jewel.JewelDecoratedDialog
 import io.github.kdroidfilter.nucleus.window.jewel.JewelDialogTitleBar
+import dev.nucleus.scheduleit.data.drive.GoogleDriveStatus
 import dev.nucleus.scheduleit.domain.AppDayOfWeek
 import dev.nucleus.scheduleit.presentation.schedule.ScheduleIntent
 import dev.nucleus.scheduleit.presentation.schedule.ScheduleUiState
@@ -49,15 +50,33 @@ import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.VerticalScrollbar
 import scheduleit.shared.generated.resources.Res
 import scheduleit.shared.generated.resources.action_cancel
+import scheduleit.shared.generated.resources.action_drive_backup_now
+import scheduleit.shared.generated.resources.action_drive_connect
+import scheduleit.shared.generated.resources.action_drive_disconnect
+import scheduleit.shared.generated.resources.action_drive_restore
+import scheduleit.shared.generated.resources.action_drive_retry
 import scheduleit.shared.generated.resources.action_export
 import scheduleit.shared.generated.resources.action_import
 import scheduleit.shared.generated.resources.action_reset_confirm
 import scheduleit.shared.generated.resources.action_reset_database
+import scheduleit.shared.generated.resources.action_restore_confirm
 import scheduleit.shared.generated.resources.reset_confirm_message
 import scheduleit.shared.generated.resources.reset_confirm_title
+import scheduleit.shared.generated.resources.restore_confirm_message
+import scheduleit.shared.generated.resources.restore_confirm_title
 import scheduleit.shared.generated.resources.settings_data_section
 import scheduleit.shared.generated.resources.settings_days_explanation
 import scheduleit.shared.generated.resources.settings_days_section
+import scheduleit.shared.generated.resources.settings_drive_connected
+import scheduleit.shared.generated.resources.settings_drive_connected_anon
+import scheduleit.shared.generated.resources.settings_drive_connecting
+import scheduleit.shared.generated.resources.settings_drive_disconnected
+import scheduleit.shared.generated.resources.settings_drive_error
+import scheduleit.shared.generated.resources.settings_drive_last_backup
+import scheduleit.shared.generated.resources.settings_drive_no_backup
+import scheduleit.shared.generated.resources.settings_drive_restoring
+import scheduleit.shared.generated.resources.settings_drive_section
+import scheduleit.shared.generated.resources.settings_drive_uploading
 import scheduleit.shared.generated.resources.settings_end_hour
 import scheduleit.shared.generated.resources.settings_hours_range_label
 import scheduleit.shared.generated.resources.settings_hours_section
@@ -125,6 +144,10 @@ fun JewelSettingsWindow(
                 //     onIntent = onIntent,
                 // )
 
+                state.googleDrive?.let { driveStatus ->
+                    GoogleDriveSection(status = driveStatus, onIntent = onIntent)
+                }
+
                 DataSection(onIntent = onIntent)
             }
             VerticalScrollbar(
@@ -150,6 +173,133 @@ private fun NotificationsSection(
             text = stringResource(Res.string.settings_notifications_label),
         )
     }
+}
+
+@Composable
+private fun GoogleDriveSection(
+    status: GoogleDriveStatus,
+    onIntent: (ScheduleIntent) -> Unit,
+) {
+    var showRestoreConfirm by remember { mutableStateOf(false) }
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        GroupHeader(stringResource(Res.string.settings_drive_section))
+        when (status) {
+            is GoogleDriveStatus.Disconnected -> {
+                Text(
+                    stringResource(Res.string.settings_drive_disconnected),
+                    color = JewelTheme.globalColors.text.info,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    DefaultButton(onClick = { onIntent(ScheduleIntent.ConnectGoogleDrive) }) {
+                        Text(stringResource(Res.string.action_drive_connect))
+                    }
+                }
+            }
+            is GoogleDriveStatus.Connecting -> {
+                Text(
+                    stringResource(Res.string.settings_drive_connecting),
+                    color = JewelTheme.globalColors.text.info,
+                )
+            }
+            is GoogleDriveStatus.Connected -> {
+                val accountText = status.email
+                    ?.let { stringResource(Res.string.settings_drive_connected, it) }
+                    ?: stringResource(Res.string.settings_drive_connected_anon)
+                Text(accountText)
+                val statusText = when (status.operation) {
+                    GoogleDriveStatus.Operation.Uploading -> stringResource(Res.string.settings_drive_uploading)
+                    GoogleDriveStatus.Operation.Restoring -> stringResource(Res.string.settings_drive_restoring)
+                    null -> when (val ts = status.lastBackupEpochSec) {
+                        null -> stringResource(Res.string.settings_drive_no_backup)
+                        else -> stringResource(Res.string.settings_drive_last_backup, formatBackupTimestamp(ts))
+                    }
+                }
+                Text(statusText, color = JewelTheme.globalColors.text.info)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    DefaultButton(
+                        onClick = { onIntent(ScheduleIntent.BackupNowToDrive) },
+                        enabled = status.operation == null,
+                    ) {
+                        Text(stringResource(Res.string.action_drive_backup_now))
+                    }
+                    OutlinedButton(
+                        onClick = { showRestoreConfirm = true },
+                        enabled = status.operation == null,
+                    ) {
+                        Text(stringResource(Res.string.action_drive_restore))
+                    }
+                    OutlinedButton(onClick = { onIntent(ScheduleIntent.DisconnectGoogleDrive) }) {
+                        Text(stringResource(Res.string.action_drive_disconnect))
+                    }
+                }
+            }
+            is GoogleDriveStatus.Error -> {
+                Text(
+                    stringResource(Res.string.settings_drive_error, status.message),
+                    color = JewelTheme.globalColors.text.error,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    DefaultButton(onClick = { onIntent(ScheduleIntent.ConnectGoogleDrive) }) {
+                        Text(stringResource(Res.string.action_drive_retry))
+                    }
+                    OutlinedButton(onClick = { onIntent(ScheduleIntent.DisconnectGoogleDrive) }) {
+                        Text(stringResource(Res.string.action_drive_disconnect))
+                    }
+                }
+            }
+        }
+    }
+    if (showRestoreConfirm) {
+        RestoreConfirmDialog(
+            onConfirm = {
+                showRestoreConfirm = false
+                onIntent(ScheduleIntent.RestoreFromDrive)
+            },
+            onCancel = { showRestoreConfirm = false },
+        )
+    }
+}
+
+@Composable
+private fun RestoreConfirmDialog(
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val dialogState = rememberDialogState(size = DpSize(420.dp, 200.dp))
+    val title = stringResource(Res.string.restore_confirm_title)
+    JewelDecoratedDialog(
+        onCloseRequest = onCancel,
+        state = dialogState,
+        title = title,
+    ) {
+        JewelDialogTitleBar { _ -> Text(title) }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(JewelTheme.globalColors.panelBackground)
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(stringResource(Res.string.restore_confirm_message))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+            ) {
+                OutlinedButton(onClick = onCancel) {
+                    Text(stringResource(Res.string.action_cancel))
+                }
+                DefaultButton(onClick = onConfirm) {
+                    Text(stringResource(Res.string.action_restore_confirm))
+                }
+            }
+        }
+    }
+}
+
+private fun formatBackupTimestamp(epochSec: Long): String {
+    val instant = java.time.Instant.ofEpochSecond(epochSec)
+    val zoned = instant.atZone(java.time.ZoneId.systemDefault())
+    return zoned.format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
 }
 
 @Composable


### PR DESCRIPTION
## Summary

- **OAuth2 PKCE flow** with loopback receiver bound explicitly to `127.0.0.1` (no Windows Firewall prompt) and the system browser; `client_id`/`client_secret` injected at compile time via `GOOGLE_DRIVE_CLIENT_ID` / `GOOGLE_DRIVE_CLIENT_SECRET` env vars (already wired as GitHub secrets in `build.yml`)
- **Backup** uploads the existing `ScheduleSnapshot` JSON into the user's hidden Drive `appDataFolder` (multipart create on first run, PATCH `uploadType=media` afterwards)
- **Restore** looks up the latest backup by name (`spaces=appDataFolder`, `orderBy=modifiedTime desc`) so the flow works on a fresh machine after Google sign-in, with a confirmation dialog before overwriting local data
- HTTP via **Ktor 3.4.3 (CIO)** + **`nucleus.native-http-ktor`** (`installNativeSsl()`) — no Google Java client libs
- **Token storage**: AES-GCM encrypted file under `%APPDATA%` / `~/Library/Application Support` / `$XDG_DATA_HOME`, owner-only permissions
- **Multiplatform-aware**: `GoogleDriveSync` is `expect` in `commonMain`; Android/iOS return `null` so the UI section is hidden on mobile
- Strings localized in EN / FR / HE

## Test plan

- [x] Set `GOOGLE_DRIVE_CLIENT_ID` / `GOOGLE_DRIVE_CLIENT_SECRET` env vars and run `./gradlew :desktopApp:run`
- [x] Open Settings → "Google Drive backup" → click **Connect Google Drive** → complete consent in browser → status shows `Connected as <email>`
- [x] Click **Back up now** → status shows `Uploading…` then `Last backup: <timestamp>`; verify the file appears under drive.google.com → Settings → Manage apps
- [x] Reset DB or delete a few events → click **Restore** → confirm → local schedule is replaced by the backup contents
- [x] Disconnect → token files removed from app data dir; section returns to disconnected state
- [x] On Android / iOS builds the section is hidden (no Drive credentials available)
- [x] CI: build artifacts are produced with secrets injected (Linux deb, Windows nsis/AppX, macOS DMG)