### PR TITLE
Mirror values-he to values-iw at build time for legacy Android Hebrew

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -154,6 +154,61 @@ tasks.matching { it.name == "compileKotlinJvm" }.configureEach {
     dependsOn(generateDriveOAuthConfig)
 }
 
+// Hebrew uses the legacy ISO 639-1 code "iw" on Android < 4.2 and "he" from 4.2+.
+// Mirror values-he into a temporary values-iw at build time and remove it once
+// Compose has consumed it, so the source tree stays clean.
+abstract class DuplicateHebrewStringsTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    val sourceFile = project.file("src/commonMain/composeResources/values-he/strings.xml")
+
+    @get:OutputFile
+    val targetFile = project.file("src/commonMain/composeResources/values-iw/strings.xml")
+
+    init {
+        onlyIf { sourceFile.exists() }
+    }
+
+    @TaskAction
+    fun duplicateStrings() {
+        targetFile.parentFile.mkdirs()
+        sourceFile.copyTo(targetFile, overwrite = true)
+    }
+}
+
+abstract class CleanupValuesIwDirectoryTask : DefaultTask() {
+    private val valuesIwDir = project.file("src/commonMain/composeResources/values-iw")
+
+    @TaskAction
+    fun cleanupDirectory() {
+        if (valuesIwDir.exists()) {
+            valuesIwDir.deleteRecursively()
+        }
+    }
+}
+
+tasks.register<DuplicateHebrewStringsTask>("duplicateHebrewStrings") {
+    description = "Duplicates Hebrew strings from values-he to values-iw for legacy Android compatibility"
+    group = "build"
+}
+
+tasks.register<CleanupValuesIwDirectoryTask>("cleanupValuesIwDirectory") {
+    description = "Deletes the temporary values-iw directory once Compose resources have been prepared"
+    group = "build"
+}
+
+// All Compose tasks that read from commonMain must see values-iw and trigger cleanup afterwards.
+val composeCommonMainResourceTasks = setOf(
+    "prepareComposeResourcesTaskForCommonMain",
+    "convertXmlValueResourcesForCommonMain",
+    "copyNonXmlValueResourcesForCommonMain",
+)
+
+tasks.matching { it.name in composeCommonMainResourceTasks }.configureEach {
+    dependsOn("duplicateHebrewStrings")
+    finalizedBy("cleanupValuesIwDirectory")
+}
+
 compose.resources {
     publicResClass = true
 }


### PR DESCRIPTION
## Summary
- Android < 4.2 reports Hebrew as `iw` (legacy ISO 639-1) while 4.2+ uses `he`. Without a `values-iw` bundle, older devices fall back to English.
- Adds two Gradle tasks in `shared/build.gradle.kts`: `duplicateHebrewStrings` mirrors `values-he/strings.xml` into a temporary `values-iw/`, and `cleanupValuesIwDirectory` removes it once Compose has consumed the resources — the source tree stays clean.
- Wired as `dependsOn` + `finalizedBy` on every Compose `*ForCommonMain` resource task so Gradle's input/output validation is satisfied.

## Test plan
- [x] `./gradlew :shared:clean :shared:copyAndroidMainComposeResourcesToAndroidAssets` runs the full chain (`duplicateHebrewStrings` → Compose prep → `cleanupValuesIwDirectory`) and leaves the source tree clean.
- [x] `values-iw/strings.commonMain.cvr` is present in the Android assets output.
- [ ] Smoke-test Hebrew locale on a < API 17 emulator (or any device reporting `iw`).