### PR TITLE
Force LTR layout for time stepper in RTL locales

### DIFF
--- a/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelTimePicker.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleus/scheduleit/ui/jewel/JewelTimePicker.kt
@@ -12,10 +12,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.jewel.foundation.theme.JewelTheme
@@ -45,39 +48,41 @@ fun JewelTimePicker(
 
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(label, color = JewelTheme.globalColors.text.info)
-        Row(
-            modifier = Modifier
-                .clip(shape)
-                .background(JewelTheme.globalColors.panelBackground)
-                .border(1.dp, JewelTheme.globalColors.borders.normal, shape)
-                .padding(horizontal = 10.dp, vertical = 6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            StepperColumn(
-                value = hour,
-                onUp = {
-                    val target = (valueMinute + 60).coerceAtMost(rangeEnd)
-                    if (target != valueMinute) onChange(target) else onBlocked?.invoke(true)
-                },
-                onDown = {
-                    val target = (valueMinute - 60).coerceAtLeast(rangeStart)
-                    if (target != valueMinute) onChange(target) else onBlocked?.invoke(false)
-                },
-            )
-            Spacer(Modifier.width(6.dp))
-            Text(":", fontWeight = FontWeight.SemiBold)
-            Spacer(Modifier.width(6.dp))
-            StepperColumn(
-                value = minute,
-                onUp = {
-                    val target = (valueMinute + stepMinutes).coerceAtMost(rangeEnd)
-                    if (target != valueMinute) onChange(target) else onBlocked?.invoke(true)
-                },
-                onDown = {
-                    val target = (valueMinute - stepMinutes).coerceAtLeast(rangeStart)
-                    if (target != valueMinute) onChange(target) else onBlocked?.invoke(false)
-                },
-            )
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+            Row(
+                modifier = Modifier
+                    .clip(shape)
+                    .background(JewelTheme.globalColors.panelBackground)
+                    .border(1.dp, JewelTheme.globalColors.borders.normal, shape)
+                    .padding(horizontal = 10.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                StepperColumn(
+                    value = hour,
+                    onUp = {
+                        val target = (valueMinute + 60).coerceAtMost(rangeEnd)
+                        if (target != valueMinute) onChange(target) else onBlocked?.invoke(true)
+                    },
+                    onDown = {
+                        val target = (valueMinute - 60).coerceAtLeast(rangeStart)
+                        if (target != valueMinute) onChange(target) else onBlocked?.invoke(false)
+                    },
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(":", fontWeight = FontWeight.SemiBold)
+                Spacer(Modifier.width(6.dp))
+                StepperColumn(
+                    value = minute,
+                    onUp = {
+                        val target = (valueMinute + stepMinutes).coerceAtMost(rangeEnd)
+                        if (target != valueMinute) onChange(target) else onBlocked?.invoke(true)
+                    },
+                    onDown = {
+                        val target = (valueMinute - stepMinutes).coerceAtLeast(rangeStart)
+                        if (target != valueMinute) onChange(target) else onBlocked?.invoke(false)
+                    },
+                )
+            }
         }
     }
 }
@@ -93,27 +98,29 @@ fun JewelHourPicker(
     val shape = RoundedCornerShape(10.dp)
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(label, color = JewelTheme.globalColors.text.info)
-        Row(
-            modifier = Modifier
-                .clip(shape)
-                .background(JewelTheme.globalColors.panelBackground)
-                .border(1.dp, JewelTheme.globalColors.borders.normal, shape)
-                .padding(horizontal = 10.dp, vertical = 6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            StepperColumn(
-                value = valueHour,
-                onUp = {
-                    val target = (valueHour + 1).coerceAtMost(range.last)
-                    if (target != valueHour) onChange(target)
-                },
-                onDown = {
-                    val target = (valueHour - 1).coerceAtLeast(range.first)
-                    if (target != valueHour) onChange(target)
-                },
-            )
-            Spacer(Modifier.width(6.dp))
-            Text("00", color = JewelTheme.globalColors.text.info)
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+            Row(
+                modifier = Modifier
+                    .clip(shape)
+                    .background(JewelTheme.globalColors.panelBackground)
+                    .border(1.dp, JewelTheme.globalColors.borders.normal, shape)
+                    .padding(horizontal = 10.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                StepperColumn(
+                    value = valueHour,
+                    onUp = {
+                        val target = (valueHour + 1).coerceAtMost(range.last)
+                        if (target != valueHour) onChange(target)
+                    },
+                    onDown = {
+                        val target = (valueHour - 1).coerceAtLeast(range.first)
+                        if (target != valueHour) onChange(target)
+                    },
+                )
+                Spacer(Modifier.width(6.dp))
+                Text("00", color = JewelTheme.globalColors.text.info)
+            }
         }
     }
 }

--- a/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/mobile/components/MobileTimePicker.kt
+++ b/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/mobile/components/MobileTimePicker.kt
@@ -12,11 +12,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.nucleus.scheduleit.ui.mobile.theme.MobileTheme
@@ -59,40 +62,42 @@ fun MobileTimePicker(
                 letterSpacing = 0.6.sp,
             ),
         )
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            StepperColumn(
-                value = hour,
-                onUp = {
-                    val target = (valueMinute + 60).coerceAtMost(rangeEnd)
-                    if (target != valueMinute) onChange(target) else onBlocked?.invoke(true)
-                },
-                onDown = {
-                    val target = (valueMinute - 60).coerceAtLeast(rangeStart)
-                    if (target != valueMinute) onChange(target) else onBlocked?.invoke(false)
-                },
-            )
-            BasicText(
-                text = ":",
-                style = TextStyle(
-                    color = colors.text,
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.SemiBold,
-                ),
-            )
-            StepperColumn(
-                value = minute,
-                onUp = {
-                    val target = (valueMinute + stepMinutes).coerceAtMost(rangeEnd)
-                    if (target != valueMinute) onChange(target) else onBlocked?.invoke(true)
-                },
-                onDown = {
-                    val target = (valueMinute - stepMinutes).coerceAtLeast(rangeStart)
-                    if (target != valueMinute) onChange(target) else onBlocked?.invoke(false)
-                },
-            )
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                StepperColumn(
+                    value = hour,
+                    onUp = {
+                        val target = (valueMinute + 60).coerceAtMost(rangeEnd)
+                        if (target != valueMinute) onChange(target) else onBlocked?.invoke(true)
+                    },
+                    onDown = {
+                        val target = (valueMinute - 60).coerceAtLeast(rangeStart)
+                        if (target != valueMinute) onChange(target) else onBlocked?.invoke(false)
+                    },
+                )
+                BasicText(
+                    text = ":",
+                    style = TextStyle(
+                        color = colors.text,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    ),
+                )
+                StepperColumn(
+                    value = minute,
+                    onUp = {
+                        val target = (valueMinute + stepMinutes).coerceAtMost(rangeEnd)
+                        if (target != valueMinute) onChange(target) else onBlocked?.invoke(true)
+                    },
+                    onDown = {
+                        val target = (valueMinute - stepMinutes).coerceAtLeast(rangeStart)
+                        if (target != valueMinute) onChange(target) else onBlocked?.invoke(false)
+                    },
+                )
+            }
         }
     }
 }
@@ -125,29 +130,31 @@ fun MobileHourPicker(
                 letterSpacing = 0.6.sp,
             ),
         )
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            StepperColumn(
-                value = valueHour,
-                onUp = {
-                    val target = (valueHour + 1).coerceAtMost(range.last)
-                    if (target != valueHour) onChange(target)
-                },
-                onDown = {
-                    val target = (valueHour - 1).coerceAtLeast(range.first)
-                    if (target != valueHour) onChange(target)
-                },
-            )
-            BasicText(
-                text = ":00",
-                style = TextStyle(
-                    color = colors.textSec,
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.SemiBold,
-                ),
-            )
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                StepperColumn(
+                    value = valueHour,
+                    onUp = {
+                        val target = (valueHour + 1).coerceAtMost(range.last)
+                        if (target != valueHour) onChange(target)
+                    },
+                    onDown = {
+                        val target = (valueHour - 1).coerceAtLeast(range.first)
+                        if (target != valueHour) onChange(target)
+                    },
+                )
+                BasicText(
+                    text = ":00",
+                    style = TextStyle(
+                        color = colors.textSec,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    ),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Wrap the hour:minute and hour-only stepper rows in `CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr)` so the order stays `HH:MM` / `HH:00` under Hebrew/Arabic.
- Applies to event editor, settings, and onboarding on both mobile (Compose) and desktop (Jewel).

## Test plan
- [ ] Mobile (Android/iOS) in Hebrew: open add/modify event — hour is on the left of `:`, minute on the right.
- [ ] Mobile settings sheet in Hebrew: working hours stepper renders LTR.
- [ ] Mobile onboarding in Hebrew: hour pickers render LTR.
- [ ] Desktop (Jewel) in Hebrew: same checks for event editor, settings window, onboarding.
- [ ] Confirm LTR locales (English/French) are unchanged.