### PR TITLE
Translate hardcoded "Time" and "Close" strings in mobile UI

### DIFF
--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -55,6 +55,7 @@
     <string name="event_dialog_new_title">Nouvel événement</string>
     <string name="event_dialog_edit_title">Modifier l&#8217;événement</string>
     <string name="event_field_title">Titre</string>
+    <string name="event_field_time">Heure</string>
     <string name="event_field_start">Début</string>
     <string name="event_field_end">Fin</string>
     <string name="event_field_color">Couleur</string>

--- a/shared/src/commonMain/composeResources/values-he/strings.xml
+++ b/shared/src/commonMain/composeResources/values-he/strings.xml
@@ -55,6 +55,7 @@
     <string name="event_dialog_new_title">אירוע חדש</string>
     <string name="event_dialog_edit_title">עריכת אירוע</string>
     <string name="event_field_title">כותרת</string>
+    <string name="event_field_time">שעה</string>
     <string name="event_field_start">התחלה</string>
     <string name="event_field_end">סיום</string>
     <string name="event_field_color">צבע</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="event_dialog_new_title">New event</string>
     <string name="event_dialog_edit_title">Edit event</string>
     <string name="event_field_title">Title</string>
+    <string name="event_field_time">Time</string>
     <string name="event_field_start">Start</string>
     <string name="event_field_end">End</string>
     <string name="event_field_color">Color</string>

--- a/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/mobile/components/ModalSheet.kt
+++ b/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/mobile/components/ModalSheet.kt
@@ -40,6 +40,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.nucleus.scheduleit.ui.mobile.theme.MobileTheme
+import org.jetbrains.compose.resources.stringResource
+import scheduleit.shared.generated.resources.Res
+import scheduleit.shared.generated.resources.action_close
 
 /**
  * Bottom sheet with native-like slide-up entrance and slide-down exit.
@@ -136,7 +139,7 @@ fun ModalSheet(
                             fontWeight = FontWeight.Bold,
                         ),
                     )
-                    IconBtn(onClick = onDismiss, contentDescription = "Close") {
+                    IconBtn(onClick = onDismiss, contentDescription = stringResource(Res.string.action_close)) {
                         IconClose(
                             modifier = Modifier
                                 .padding(2.dp)

--- a/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/mobile/screens/MobileEventEditor.kt
+++ b/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/mobile/screens/MobileEventEditor.kt
@@ -53,6 +53,7 @@ import scheduleit.shared.generated.resources.event_field_color
 import scheduleit.shared.generated.resources.event_field_end
 import scheduleit.shared.generated.resources.event_field_notes
 import scheduleit.shared.generated.resources.event_field_start
+import scheduleit.shared.generated.resources.event_field_time
 import scheduleit.shared.generated.resources.event_field_title
 import scheduleit.shared.generated.resources.event_scope_all_days
 import scheduleit.shared.generated.resources.event_scope_label
@@ -111,7 +112,7 @@ fun MobileEventEditor(
                 )
             }
 
-            SectionHeading(text = "Time")
+            SectionHeading(text = stringResource(Res.string.event_field_time))
             Row(
                 modifier = Modifier
                     .fillMaxWidth()


### PR DESCRIPTION
## Summary
- Add `event_field_time` resource (en / he / fr) for the mobile event editor's time section heading
- Replace hardcoded `"Time"` literal in `MobileEventEditor` with `stringResource`
- Replace hardcoded `"Close"` `contentDescription` in `ModalSheet` with `stringResource(action_close)`

## Test plan
- [ ] Open the event editor in Hebrew locale → "Time" heading reads "שעה"
- [ ] Open the event editor in French locale → "Time" heading reads "Heure"
- [ ] TalkBack/VoiceOver on the modal close button announces the localized label