### PR TITLE
Translate phone-day summary line under day title

### DIFF
--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -66,6 +66,8 @@
     <string name="event_scope_all_days">Tous les jours liés</string>
     <string name="action_hide_for_day">Masquer pour %1$s</string>
 
+    <string name="day_summary">%1$d événements · %2$s – %3$s</string>
+
     <string name="empty_schedule_hint">Aucun jour visible. Ouvrez les paramètres pour activer des jours.</string>
     <string name="error_invalid_range">La fin doit être postérieure au début.</string>
     <string name="error_outside_window">L&#8217;événement doit tenir dans la plage horaire visible.</string>

--- a/shared/src/commonMain/composeResources/values-he/strings.xml
+++ b/shared/src/commonMain/composeResources/values-he/strings.xml
@@ -66,6 +66,8 @@
     <string name="event_scope_all_days">כל הימים המקושרים</string>
     <string name="action_hide_for_day">הסתר עבור %1$s</string>
 
+    <string name="day_summary">%1$d אירועים · %2$s – %3$s</string>
+
     <string name="empty_schedule_hint">אין יום גלוי. פתח את ההגדרות כדי להפעיל ימים.</string>
     <string name="error_invalid_range">הסיום חייב להיות אחרי ההתחלה.</string>
     <string name="error_outside_window">האירוע חייב להיכנס לטווח השעות הגלוי.</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -66,6 +66,8 @@
     <string name="event_scope_all_days">All linked days</string>
     <string name="action_hide_for_day">Hide for %1$s</string>
 
+    <string name="day_summary">%1$d events · %2$s – %3$s</string>
+
     <string name="empty_schedule_hint">No visible day. Open settings to enable days.</string>
     <string name="error_invalid_range">End must be after start.</string>
     <string name="error_outside_window">Event must fit in the visible hour range.</string>

--- a/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/mobile/screens/PhoneDayScreen.kt
+++ b/shared/src/nonJvmMain/kotlin/dev/nucleus/scheduleit/ui/mobile/screens/PhoneDayScreen.kt
@@ -43,6 +43,7 @@ import org.jetbrains.compose.resources.stringResource
 import scheduleit.shared.generated.resources.Res
 import scheduleit.shared.generated.resources.action_add_event
 import scheduleit.shared.generated.resources.action_paste_event
+import scheduleit.shared.generated.resources.day_summary
 
 /**
  * Phone-portrait layout — header + 7-day strip + single day grid + FAB.
@@ -161,7 +162,12 @@ private fun DayTitle(
         Spacer(Modifier.height(2.dp))
         val pad = { v: Int -> v.toString().padStart(2, '0') }
         BasicText(
-            text = "$eventCount events · ${pad(startHour)}:00 – ${pad(endHour)}:00",
+            text = stringResource(
+                Res.string.day_summary,
+                eventCount,
+                "${pad(startHour)}:00",
+                "${pad(endHour)}:00",
+            ),
             style = TextStyle(
                 color = colors.textSec,
                 fontSize = typography.label,


### PR DESCRIPTION
## Summary
- The `"N events · HH:00 – HH:00"` line under the day title on phone-portrait was a hardcoded English literal
- Add a `day_summary` resource (en / he / fr) with positional placeholders
- Route `PhoneDayScreen`'s `DayTitle` through `stringResource` with the count and padded start/end times

## Test plan
- [ ] Switch to Hebrew → subtitle reads `N אירועים · 08:00 – 20:00`
- [ ] Switch to French → subtitle reads `N événements · 08:00 – 20:00`
- [ ] English unchanged