### PR TITLE
Bump nucleus to 1.14.3 to fix non-ASCII install path crash

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.11.0"
 material3 = "1.10.0-alpha05"
 metro = "1.0.0"
-nucleus = "1.14.2"
+nucleus = "1.14.3"
 sqldelight = "2.3.2"
 
 [libraries]


### PR DESCRIPTION
## Summary
- Bumps `nucleus` from `1.14.2` to `1.14.3` in `gradle/libs.versions.toml`.
- Fixes #13: app crashed immediately on launch on Windows when the username (and thus install path) contained non-ASCII characters (e.g. Hebrew), due to an ANSI/UTF-8 mismatch in the native launcher's `LoadLibrary` call.

Closes #13

## Test plan
- [ ] CI build passes on all platforms
- [ ] Verify Windows launch with a non-ASCII username (e.g. Hebrew) no longer crashes
- [ ] Smoke-test launch on Windows with a regular ASCII username (no regression)